### PR TITLE
fix (scripts): add dep and fix table name

### DIFF
--- a/scripts/postgres_data/get_data.py
+++ b/scripts/postgres_data/get_data.py
@@ -22,9 +22,9 @@ with pgsql.Connection(('localhost', 5432), user, pw, tls = False) as db:
     #print(db)
 
     with db.prepare("""
-    SELECT (xpath('/oai:record/oai:metadata', info, '{{oai, http://www.openarchives.org/OAI/2.0/},{datacite, http://datacite.org/schema/kernel-4}}'))[1] AS root
-FROM raw
-    LIMIT 1000;
+    SELECT (xpath('/oai:record/oai:metadata', raw_metadata, '{{oai, http://www.openarchives.org/OAI/2.0/},{datacite, http://datacite.org/schema/kernel-4}}'))[1] AS root
+FROM harvest_events
+    LIMIT 10;
     """) as docs:
 
         all_rows = docs()

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "xmltodict",
     "jsonschema",
     "fastembed",
+    "lxml"
 ]
 
 [build-system]


### PR DESCRIPTION
Fixes an issue with a missing dependency `lxml` for `scripts/postgres_data/import_data.py` and table name in `scripts/postgres_data/get_data.py` 