### PR TITLE
feat (fastembed): make flag to use local models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ docker-compose.override.yml
 scripts/opensearch_data/data*/*
 scripts/postgres_data/data/*
 data/results/*
+cache_*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
             context: .
         volumes:
             - ./src:/code/app
+            - ./cache_celery:/tmp/fastembed_cache
         networks:
             - warehouse-backend
         depends_on:
@@ -81,6 +82,8 @@ services:
             POSTGRES_PORT: "${POSTGRES_PORT}"
             OPENSEARCH_ADDRESS: "${OPENSEARCH_ADDRESS}"
             OPENSEARCH_PORT: "${OPENSEARCH_PORT}"
+            FASTEMBED_CACHE_PATH: "${FASTEMBED_CACHE_PATH}"
+            FASTEMBED_LOCAL_MODEL: "${FASTEMBED_LOCAL_MODEL}"
         healthcheck:
             test: celery -A tasks status
             interval: 10s
@@ -93,6 +96,7 @@ services:
             context: .
         volumes:
             - ./src:/code/app
+            - ./cache_transform:/tmp/fastembed_cache
         command: [ "fastapi", "run", "--host", "0.0.0.0", "transform.py", "--port", "80" ]
         networks:
             - warehouse-backend
@@ -108,6 +112,8 @@ services:
             OPENSEARCH_PORT: "${OPENSEARCH_PORT}"
             EMBEDDING_MODEL: "${EMBEDDING_MODEL}"
             CELERY_BATCH_SIZE: "${CELERY_BATCH_SIZE}"
+            FASTEMBED_CACHE_PATH: "${FASTEMBED_CACHE_PATH}"
+            FASTEMBED_LOCAL_MODEL: "${FASTEMBED_LOCAL_MODEL}"
         depends_on:
             postgres:
                 condition: service_healthy

--- a/env.template
+++ b/env.template
@@ -11,3 +11,5 @@ EMBEDDING_MODEL=BAAI/bge-small-en-v1.5 # https://qdrant.github.io/fastembed/exam
 EMBEDDING_DIMS=384 # depends on EMBEDDING_MODEL
 INDEX_NAME=test_datacite
 CELERY_BATCH_SIZE=250
+FASTEMBED_CACHE_PATH=/tmp/fastembed_cache
+FASTEMBED_LOCAL_MODEL=0

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -38,6 +38,12 @@ DATACITE_RESOURCE = 'http://datacite.org/schema/kernel-4:resource'
 HAL_RESOURCE = f'{OAI}:resource'
 
 EMBEDDING_MODEL = os.environ.get('EMBEDDING_MODEL')
+# determines value for local_files_only, defaults to false
+LOCAL_FILES_ONLY = os.getenv('FASTEMBED_LOCAL_MODEL', '0') == '1'
+
+print('local', LOCAL_FILES_ONLY, os.environ.get('FASTEMBED_LOCAL_MODEL'))
+
+
 if not EMBEDDING_MODEL:
     raise ValueError('Missing EMBEDDING_MODEL environment variable')
 
@@ -56,8 +62,8 @@ class TransformTask(Task):  # type: ignore
 
     def __init__(self) -> None:
         if EMBEDDING_MODEL:
-            self.embedding_transformer = TextEmbedding(model_name=EMBEDDING_MODEL)
-            logger.info(f'Setting up embedding transformer with model {EMBEDDING_MODEL}')
+            self.embedding_transformer = TextEmbedding(model_name=EMBEDDING_MODEL, local_files_only=LOCAL_FILES_ONLY)
+            logger.info(f'Setting up embedding transformer with model {EMBEDDING_MODEL} and local_files_only {LOCAL_FILES_ONLY}')
 
         opensearch_config = OpenSearchConfig()
         self.client = OpenSearch(


### PR DESCRIPTION
This PR adds some logic to use locally cached models for fastembed.
See https://github.com/qdrant/fastembed/issues/549#issuecomment-3510557866

TODO:

- [ ] figure out if one cache dir would work for both containers (transform and celery)
- [ ] make unit tests `TestEmbeddingsUtils` work without any active connection to HF: try `TextEmbedding(local_files_only=True)` or mock this 