### PR TITLE
fix: update frontend artifact pruning to include additional file types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,13 +194,13 @@ services:
             sh -c 'set -eu
             echo "Existing volume contents BEFORE prune (/frontend-volume)";
             if [ -d /frontend-volume ]; then find /frontend-volume -maxdepth 2 -type f -print || true; else echo "(volume empty or not yet created)"; fi;
-            echo "Pruning old frontend artifacts (assets/, *.html, *.svg, *.css, *.js)";
+            echo "Pruning old frontend artifacts (assets/, *.html, *.svg, *.css, *.js, *.ico, *.png)";
             rm -rf /frontend-volume/assets || true;
-            find /frontend-volume -maxdepth 1 -type f \( -name "*.html" -o -name "*.svg" -o -name "*.css" -o -name "*.js" \) -exec rm -f {} + || true;
+            find /frontend-volume -maxdepth 1 -type f \( -name "*.html" -o -name "*.svg" -o -name "*.css" -o -name "*.js" -o -name "*.ico" -o -name "*.png" \) -exec rm -f {} + || true;
             echo "Copying updated assets directory";
             if [ -d /webapp/assets ]; then cp -a /webapp/assets /frontend-volume/; fi;
-            echo "Copying root-level *.html / *.svg / *.css / *.js";
-            find /webapp -maxdepth 1 -type f \( -name "*.html" -o -name "*.svg" -o -name "*.css" -o -name "*.js" \) -exec cp -f {} /frontend-volume/ \+;
+            echo "Copying root-level files (*.html, *.svg, *.css, *.js, *.ico, *.png)";
+            find /webapp -maxdepth 1 -type f \( -name "*.html" -o -name "*.svg" -o -name "*.css" -o -name "*.js" -o -name "*.ico" -o -name "*.png" \) -exec cp -f {} /frontend-volume/ \+;
             echo "Final volume contents AFTER copy";
             find /frontend-volume -maxdepth 2 -type f -print'
         volumes:


### PR DESCRIPTION
This pull request updates the Docker Compose configuration to ensure that additional frontend file types are properly handled during the asset cleanup and copy process. Specifically, it expands the list of file extensions that are pruned and copied to include `.ico` and `.png` files, alongside the previously handled types.