### PR TITLE
Add docker volume for search API logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,7 @@ services:
                 condition: service_completed_successfully
         volumes:
             - frontend-data:/src/webapp
+            - search-api-data:/app/data
         env_file: [ keys.env ]
         environment:
             - RUST_LOG=info
@@ -231,6 +232,7 @@ volumes:
     opensearch-dashboards-data:
     broker-data:
     flower-data:
+    search-api-data:
     frontend-data:
 
 networks:


### PR DESCRIPTION
Add docker volume in `docker-compose.yml` for the search API data, for now mainly to make the conversations logs persistent (will need to see later how we want to store and access these logs on the long run)