### PR TITLE
Fix harvester container in the docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To run the containers:
 - load XML data from `scripts/postgres_data/data` (populates table `harvest_events`):
   ```sh
    uv run import_data.py
-   ```
+  ```
 
 - transform data from `scripts/postgres_data/data` to a local dir
   (to test transformation, alternative to using the Celery process):
@@ -99,9 +99,9 @@ and the harvest run is then closed. Note that a transformation can only be perfo
   ```
 
 - To obtain a harvest run id and status for a given endpoint (https://dabar.srce.hr/oai):
-```sh
+  ```sh
   http://127.0.0.1:8080/harvest_run?harvest_url=https%3A%2F%2Fdabar.srce.hr%2Foai
-```
+  ```
 
 - start transformation process:
   ```sh
@@ -111,4 +111,10 @@ and the harvest run is then closed. Note that a transformation can only be perfo
   ```sh
   http://127.0.0.1:5555/tasks
   ```
+
+After starting the stack with `docker compose up`, you can run the harvester for a given repository URL, e.g.:
+
+```sh
+docker compose run harvester https://lifesciences.datastations.nl/oai
+```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,7 @@ services:
     # https://github.com/EOSC-Data-Commons/metadata-crawlers/pkgs/container/metadata-crawlers
     harvester:
         image: ghcr.io/eosc-data-commons/metadata-crawlers:latest
+        profiles: ["manual"]
         env_file:
             - .env
         volumes:


### PR DESCRIPTION
Make it so the harvester container is manually triggered instead of starting with `docker compose up`

It is not a service, its a script that takes arguments, which are currently missing from the compose, so it will just fail with an error message asking to provide a repository URL to harvest

But that is for the people who can actually run it, because for now the metadata-crawler docker image is only built for amd64, there is no image available for arm64, so it fails to pull on macOS

I also added instruction to run the harvester container alongside the running stack in the readme

Right now many people need to comment out the harvester line in the compose file to be able to deploy the warehouse locally

@tobiasschweizer @Michal-Kolomanski 