### PR TITLE
feat (harvest event): register JSON as raw metadata

### DIFF
--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -204,7 +204,8 @@ def test_create_and_close_harvest_run(api_client, flower_client, reset_db, reset
     post_he = api_client.post('/harvest_event', json={
         "record_identifier": "10.34894/G8PZKV",
         "datestamp": "2026-02-17T15:43:03.326Z",
-        "raw_metadata": f"{xml}",
+        "raw_metadata": '{"id": "hahuhi"}',
+        "metadata_format": "JSON",
         "harvest_url": "https://demo.onedata.org/oai_pmh",
         "repo_code": "DANS",
         "harvest_run_id": create_response['id'],

--- a/scripts/postgres_data/create_sql/datasetdb/tables.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/tables.sql
@@ -98,8 +98,9 @@ CREATE TABLE IF NOT EXISTS harvest_events (
     endpoint_id UUID NOT NULL,
     harvest_run_id UUID NOT NULL,
     record_identifier VARCHAR(255) NOT NULL,
-    raw_metadata XML NOT NULL,
-    metadata_format content_format NOT NULL DEFAULT 'XML',
+    raw_metadata_xml XML,
+    raw_metadata_json JSONB,
+    metadata_format content_format NOT NULL,
     metadata_protocol harvest_protocol NOT NULL,
     additional_metadata TEXT,
     datestamp TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -115,9 +116,16 @@ CREATE TABLE IF NOT EXISTS harvest_events (
         REFERENCES harvest_runs(id) ON DELETE CASCADE
 );
 
+ALTER TABLE harvest_events
+ADD CONSTRAINT harvest_events_raw_metadata_check CHECK (
+    (raw_metadata_xml IS NOT NULL AND raw_metadata_json IS NULL) OR
+    (raw_metadata_xml IS NULL AND raw_metadata_json IS NOT NULL)
+);
+
 COMMENT ON TABLE harvest_events IS 'Queue of harvested metadata events awaiting transformation';
 COMMENT ON COLUMN harvest_events.record_identifier IS 'OAI-PMH identifier or unique record ID';
-COMMENT ON COLUMN harvest_events.raw_metadata IS 'Original harvested metadata (XML, JSON, etc.)';
+COMMENT ON COLUMN harvest_events.raw_metadata_xml IS 'Original harvested metadata (XML)';
+COMMENT ON COLUMN harvest_events.raw_metadata_json IS 'Original harvested metadata (JSON)';
 COMMENT ON COLUMN harvest_events.metadata_format IS 'Format of the raw metadata';
 COMMENT ON COLUMN harvest_events.metadata_protocol IS 'Protocol used to harvest this event';
 COMMENT ON COLUMN harvest_events.additional_metadata IS 'Additional metadata from REST APIs etc., includes source protocol';

--- a/src/transform.py
+++ b/src/transform.py
@@ -87,7 +87,8 @@ class Config(BaseModel):
 class HarvestEventCreateRequest(BaseModel):
     record_identifier: str
     datestamp: datetime
-    raw_metadata: str  # XML
+    raw_metadata: str  # XML or JSON
+    metadata_format: str # XML or JSON
     additional_metadata: Optional[str] = None  # XML or JSON (stringified)
     harvest_url: str
     repo_code: str
@@ -297,6 +298,9 @@ def close_harvest_run_in_db(harvest_run: HarvestRunCloseRequest) -> HarvestRunCl
 
 
 def create_harvest_event_in_db(harvest_event: HarvestEventCreateRequest) -> HarvestEventCreateResponse:
+
+    logger.debug(f'{harvest_event}')
+
     """
     Creates a record in table harvest_events
 
@@ -306,34 +310,40 @@ def create_harvest_event_in_db(harvest_event: HarvestEventCreateRequest) -> Harv
     with psycopg.connect(**connection_params, row_factory=dict_row) as conn:
         cur = conn.cursor()
 
+        raw_xml = harvest_event.raw_metadata if harvest_event.metadata_format == 'XML' else None
+        raw_json = harvest_event.raw_metadata if harvest_event.metadata_format == 'JSON' else None
+
         cur.execute("""
                         INSERT INTO harvest_events 
                             (record_identifier,
                             datestamp, 
-                            raw_metadata,
+                            raw_metadata_xml,
+                            raw_metadata_json,
+                            metadata_format,
                             additional_metadata,
                             repository_id, 
                             endpoint_id,  
                             metadata_protocol,
-                            metadata_format,
                             harvest_run_id,
                             is_deleted
                             ) 
                         VALUES ( 
                             %s,
                             %s, 
-                            XMLPARSE(DOCUMENT %s), 
+                            %s::XML,
+                            %s::JSONB,
+                            %s,
                             %s,
                             (SELECT id from repositories WHERE code=%s),
                             (SELECT id from endpoints WHERE harvest_url=%s), 
                             %s,
-                            %s,
                             (SELECT id FROM harvest_runs WHERE id = %s and status = 'open'),
                             %s
                             );
-                        """, (harvest_event.record_identifier, harvest_event.datestamp, harvest_event.raw_metadata,
+                        """, (harvest_event.record_identifier, harvest_event.datestamp, raw_xml, raw_json,
+                              harvest_event.metadata_format,
                               harvest_event.additional_metadata, harvest_event.repo_code, harvest_event.harvest_url,
-                              'OAI-PMH', 'XML', harvest_event.harvest_run_id, harvest_event.is_deleted))
+                              'OAI-PMH', harvest_event.harvest_run_id, harvest_event.is_deleted))
 
         cur.execute("""
         SELECT id 


### PR DESCRIPTION
Adds support to register JSON as a harvest_event.

Note that the transformation still has to be adapted.