### PR TITLE
chore: delete duplication of transfomer's api address

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ uv run python -m scheduler.run
 
 Optionally add the following env variables (not needed for local dev):
 
-- `TRANSFORMER_URL` (default "http://192.168.10.6:8080")
+- `WAREHOUSE_API_URL` (default "http://transform:80")
 - `INDEX_NAME` (default "test_datacite")
 
 ## Run E2E Tests

--- a/env.template
+++ b/env.template
@@ -17,5 +17,3 @@ FINBIF_ACCESS_TOKEN=changeme
 
 # Docker address of transformer, used by Crawler
 WAREHOUSE_API_URL=http://transform:80
-# IP address of transformer, used by Scheduler
-TRANSFORMER_URL=http://localhost:8080

--- a/scheduler/clients/transformer_client.py
+++ b/scheduler/clients/transformer_client.py
@@ -12,7 +12,7 @@ from typing import Any, Dict
 
 import requests
 
-from scheduler.config import TRANSFORMER_URL
+from scheduler.config import WAREHOUSE_API_URL
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def get_endpoints_to_harvest() -> list[str]:
     logger.info("requesting endpoints to harvest")
 
     r = requests.get(
-        f"{TRANSFORMER_URL}/harvest_run",
+        f"{WAREHOUSE_API_URL}/harvest_run",
         params={"only_active": True, "respect_schedule": True},
         timeout=30,
     )
@@ -71,7 +71,7 @@ def are_all_runs_closed() -> bool:
         True if no open harvest run exists
     """
 
-    r = requests.post(f"{TRANSFORMER_URL}/scheduler/wait-for-completion", timeout=30)
+    r = requests.post(f"{WAREHOUSE_API_URL}/scheduler/wait-for-completion", timeout=30)
 
     r.raise_for_status()
 
@@ -94,7 +94,7 @@ def get_closed_run_ids() -> list[str]:
     """
 
     logger.info("requesting closed runs")
-    r = requests.get(f"{TRANSFORMER_URL}/scheduler/closed-runs", timeout=30)
+    r = requests.get(f"{WAREHOUSE_API_URL}/scheduler/closed-runs", timeout=30)
 
     r.raise_for_status()
     data: Dict[str, Any] = r.json()
@@ -121,7 +121,7 @@ def trigger_index(run_ids: list[str], index_name: str) -> None:
         logger.info("trigger index for run %s", run_id)
 
         r = requests.get(
-            f"{TRANSFORMER_URL}/index",
+            f"{WAREHOUSE_API_URL}/index",
             params={"harvest_run_id": run_id, "index_name": index_name},
             timeout=6000,
         )

--- a/scheduler/config.py
+++ b/scheduler/config.py
@@ -11,6 +11,5 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 load_dotenv(BASE_DIR / ".env")
 
 
-TRANSFORMER_URL = os.getenv("TRANSFORMER_URL", "http://192.168.10.6:8080")
-
+WAREHOUSE_API_URL = os.getenv("WAREHOUSE_API_URL", "http://transform:80")
 INDEX_NAME = os.getenv("INDEX_NAME", "test_datacite")


### PR DESCRIPTION
`WAREHOUSE_API_URL` (used previously only in Crawler) and `TRANSFORMER_URL` were pointing to the same address. 

`TRANSFORMER_URL` was deleted