### PR TITLE
refactor (endpoint config): adapt protocol for dataverse and HAL

### DIFF
--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -27,7 +27,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://archaeology.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "REST_API", "format": "dataverse_json"}}',
+    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://archaeology.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "DATAVERSE_API", "format": "dataverse_json"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'DANS'
@@ -46,7 +46,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://ssh.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "REST_API", "format": "dataverse_json"}}',
+    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://ssh.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "DATAVERSE_API", "format": "dataverse_json"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'DANS'
@@ -65,7 +65,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://lifesciences.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "REST_API", "format": "dataverse_json"}}',
+    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://lifesciences.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "DATAVERSE_API", "format": "dataverse_json"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'DANS'
@@ -84,7 +84,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://phys-techsciences.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "REST_API", "format": "dataverse_json"}}',
+    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://phys-techsciences.datastations.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "DATAVERSE_API", "format": "dataverse_json"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'DANS'
@@ -103,7 +103,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://dataverse.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "REST_API", "format": "dataverse_json"}}',
+    '{"metadata_prefix": "oai_datacite", "additional_metadata_params": {"endpoint": "https://dataverse.nl/api/datasets/:persistentId/versions/:latest-published", "protocol": "DATAVERSE_API", "format": "dataverse_json"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'DANS'
@@ -160,7 +160,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "set": ["collection:LINKED_RESEARCH_OUTPUTS"]}',
+    '{"metadata_prefix": "oai_datacite", "set": ["collection:LINKED_RESEARCH_OUTPUTS"], "additional_metadata_params": {"endpoint": "https://api.archives-ouvertes.fr/search/", "protocol": "HAL_API"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'HAL'

--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -160,7 +160,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "set": ["collection:LINKED_RESEARCH_OUTPUTS"], "additional_metadata_params": {"endpoint": "https://api.archives-ouvertes.fr/search/", "protocol": "HAL_API"}}',
+    '{"metadata_prefix": "oai_datacite", "set": ["collection:LINKED_RESEARCH_OUTPUTS"], "additional_metadata_params": {"endpoint": "https://api.archives-ouvertes.fr/search/", "protocol": "HAL_API", "format": "halId_s,fileMain_s,files_s,fileType_s,modifiedDate_tdate,producedDate_tdate,version_i"}}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'HAL'

--- a/src/transform.py
+++ b/src/transform.py
@@ -53,7 +53,7 @@ class IndexGetResponse(BaseModel):
 
 
 class AdditionalMetadataParams(BaseModel):
-    format: Optional[str] = None
+    format: str
     endpoint: str
     protocol: str
 

--- a/src/transform.py
+++ b/src/transform.py
@@ -53,7 +53,7 @@ class IndexGetResponse(BaseModel):
 
 
 class AdditionalMetadataParams(BaseModel):
-    format: str
+    format: Optional[str] = None
     endpoint: str
     protocol: str
 


### PR DESCRIPTION
This PR adapt additional metadata config for Dataverse and HAL:
- "DATAVERSE_API" instead of "REST_API" since this is specific to Dataverse
- "HAL_API" for HAL

requires https://github.com/EOSC-Data-Commons/metadata-crawlers/pull/25

## SQL to update existing DB

```sql
UPDATE endpoints
SET harvest_params = jsonb_set(
    harvest_params,
    '{additional_metadata_params, protocol}',
    '"DATAVERSE_API"'
)
WHERE harvest_params #>> '{additional_metadata_params, protocol}' = 'REST_API';
```

```sql
UPDATE endpoints
SET harvest_params = jsonb_set(
    harvest_params,
    '{additional_metadata_params}',
    '{"endpoint": "https://api.archives-ouvertes.fr/search/", "protocol": "HAL_API", "format": "halId_s,fileMain_s,files_s,fileType_s,modifiedDate_tdate,producedDate_tdate,version_i"}',
    true  -- creates the key if it doesn't exist
)
WHERE name = 'HAL'
  AND harvest_params -> 'additional_metadata_params' IS NULL;
```
 