### PR TITLE
add utf-8 encoding when opening file

### DIFF
--- a/scripts/postgres_data/transform.py
+++ b/scripts/postgres_data/transform.py
@@ -20,7 +20,7 @@ from src.utils.normalize_datacite_json import normalize_datacite_json
 
 def transform_record(filepath: Path, output_dir: Path, normalize: bool, schema: Optional[dict[Any, Any]]) -> None:
     try:
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             contents = f.read()
             converted = xmltodict.parse(contents, process_namespaces=True)
 


### PR DESCRIPTION
We should specify in what encoding we want to open certain files because on windows for example it won't open it in utf-8 when there is no encoding specified. I runned transform proces locally to see where certain transformation failed and it kept throwing me unicode reading error because it coudn't read certain characters. This change should fix these issue.