### PR TITLE
fix (onedata): use new set name

### DIFF
--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -182,7 +182,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "set": ["a842ea97ec1855a54bf77a90e915cac7cha3ab"]}',
+    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e"]}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'ONE'


### PR DESCRIPTION
This PR changes the OneData set name since the old set is deprecated, see https://eoscdatacommons.slack.com/archives/C0AV49S2CDA/p1778259007583339