### PR TITLE
chore: extend onedata sets

### DIFF
--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -182,7 +182,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e"]}',
+    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e", "a93d0c2877c38910bd10bc458e266debch24b6"]}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'ONE'

--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -182,7 +182,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e", "a93d0c2877c38910bd10bc458e266debch24b6"]}',
+    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e", "a93d0c2877c38910bd10bc458e266debch24b6", "6606a96229a922e4c757c0c99e593318ch4848"]}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'ONE'


### PR DESCRIPTION
Onedata sets extended with:
- [x] TopAnat `a93d0c2877c38910bd10bc458e266debch24b6`
- [x] VIP `6606a96229a922e4c757c0c99e593318ch4848`