### PR TITLE
Add metadata enrichment endpoint "init_subjects" to fill raw_subjects based on raw_metadata and set enriched_subjects to empty arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 1.0.0 (2026-04-28)
+
+
+### Features
+
+* [[#15](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/15)] sql table design ([#16](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/16)) ([a26f19a](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/a26f19a9eb38c54118be5471f057cb6cc9343122))
+* [[#45](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/45)] workflow for a transformation report ([9ecaa2b](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/9ecaa2be1bcb99994f480ab9c590cf887bb060b1))
+* add docker volume in `docker-compose.yml` for the search API data, for now mainly to make the conversations logs persistent ([8d97f44](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/8d97f447dcbdbd68e8165ac3dfd47743f32d0dcd))
+* add scheduler ([#73](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/73)) ([a39b0db](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/a39b0dbefa6c1235fdab37e4d13b3773d8b42fee))
+* flag in scheduler for transforming all harvest_runs ([#93](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/93)) ([b1aeef4](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/b1aeef4ed20aa400209b18bf365385374299c135))
+* scheduler works in docker ([#78](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/78)) ([0c60fb8](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/0c60fb8024d86edbcf81f2960afa043a0c8e96cb))
+* trigger release gh action ([#96](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/96)) ([ba8cd8b](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/ba8cd8b56570696e822f02247077489b7271b140))
+
+
+### Bug Fixes
+
+* [[#35](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/35)] use index_name in transformer ([#38](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/38)) ([039c5c3](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/039c5c371eef2e46f972b9fa740c023c75acaabf))
+* handle failed harvest_runs ([#80](https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/80)) ([926a209](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/926a209005f06d842c5bbfb83f4daa4c9410ddb5))
+* make it so the harvester container is manually triggered instead of starting with `docker compose up`. It is not a service, its a script that takes arguments (which are currently missing from the compose). Added instruction to run the harvester container in the readme ([112cd83](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/112cd83be0108e9063a91cd4ed8af02d3f3a3ae6))
+* update frontend artifact pruning to include additional file types ([49532b6](https://github.com/EOSC-Data-Commons/metadata-warehouse/commit/49532b674b4d2a93f656d97741167871390a17ba))

--- a/src/transform.py
+++ b/src/transform.py
@@ -639,6 +639,112 @@ def are_all_runs_closed_in_db() -> bool:
 
         return not result['has_open_runs']
 
+def init_record_subjects() -> bool:
+    """
+    Create 'raw_subjects' and 'enriched_subjects' fields in the record table.  
+    If the columns don't exist, they will be created.  
+    If they exist, they will be re-initialized. 'raw_subjects' is gathered from 'raw_metadata'.  
+    'enriched_subjects' will be identical to 'raw_subjects'! Further enrichment methods will
+    extend them with additional subjects.
+
+    A record's subjects will be recognised if they exist in any of the structures defined in
+    the various xpath() calls in the SQL query.  
+    The fields will be arrays of text values. So a record with no subjects will have an array length
+    of zero. Using array_to_string will concatenate them into a single string.
+
+    Returns
+    -------
+    bool
+        True if the initialization is completed successfuly.
+    """
+    with psycopg.connect(**connection_params, row_factory=dict_row) as conn:
+        cur = conn.cursor()
+
+        # Altering the records schema if the columns don't exist.
+        # If they exist, the queries don't change anything
+
+        # Column raw_subjects
+        cur.execute("""
+            DO $$
+            BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'records'
+                AND column_name = 'raw_subjects'
+            ) THEN
+                ALTER TABLE records ADD COLUMN raw_subjects text[];
+            END IF;
+            END;
+            $$;
+        """)
+
+        
+        # Column enriched_subjects
+        cur.execute("""
+            DO $$
+            BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'records'
+                AND column_name = 'enriched_subjects'
+            ) THEN
+                ALTER TABLE records ADD COLUMN enriched_subjects text[];
+            END IF;
+            END;
+            $$;
+        """)
+
+        # Fill the columns with subjects extracted from raw_metadata.
+        # Both column will have the same values!
+
+        cur.execute("""
+            WITH raw_subjects_extraction AS (
+                SELECT
+                    id,
+                    (
+                        xpath('oai:record/oai:metadata/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                            '{{datacite, http://datacite.org/schema/kernel-4},
+                            {oai, http://www.openarchives.org/OAI/2.0/}}'
+                        )::text[] ||
+                        xpath('oai:record/oai:metadata/oaidc:oai_datacite/oaidc:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                            '{{datacite, http://datacite.org/schema/kernel-4},
+                            {oai, http://www.openarchives.org/OAI/2.0/},
+                            {oaidc, http://schema.datacite.org/oai/oai-1.1/}}'
+                        )::text[] ||
+                        xpath('oai:record/oai:metadata/oai:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                            '{{datacite, http://datacite.org/schema/kernel-4},
+                            {oai, http://www.openarchives.org/OAI/2.0/}}'
+                        )::text[] ||
+                        xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                        -- note the 3 in datacite
+                            '{{datacite, http://datacite.org/schema/kernel-3},
+                            {oai, http://www.openarchives.org/OAI/2.0/},
+                            {oad, http://schema.datacite.org/oai/oai-1.0/}}'
+                        )::text[] ||
+                        -- same path as previous but uses kernel-4 namespace
+                        xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                            '{{datacite, http://datacite.org/schema/kernel-4},
+                            {oai, http://www.openarchives.org/OAI/2.0/},
+                            {oad, http://schema.datacite.org/oai/oai-1.0/}}'
+                        )::text[]
+                    ) AS subjects
+                FROM public.records
+            )
+            UPDATE records a
+            SET
+                raw_subjects = raw_subjects_extraction.subjects,
+                -- the enriched field will start the same as raw, and then get expanded with more subjects later
+                enriched_subjects = raw_subjects_extraction.subjects
+            FROM raw_subjects_extraction
+            WHERE a.id = raw_subjects_extraction.id;
+        """)
+                    
+
+        result = cur.fetchone()
+        if result is None:
+            raise RuntimeError('Query failed')
+
+        return True
 
 @app.get('/index', tags=['index'])
 def init_index(

--- a/src/transform.py
+++ b/src/transform.py
@@ -941,8 +941,7 @@ def init_record_subjects() -> bool:
             """)
             
 
-            # Fill the columns with subjects extracted from raw_metadata.
-            # Both column will have the same values!
+            # Fill raw_subjects with subjects extracted from raw_metadata.
 
             cur.execute("""
                 WITH raw_subjects_extraction AS (

--- a/src/transform.py
+++ b/src/transform.py
@@ -885,8 +885,7 @@ def init_record_subjects() -> bool:
 
     If the columns don't exist, they will be created.  
     If they exist, they will be re-initialized. 'raw_subjects' is gathered from 'raw_metadata'.  
-    'enriched_subjects' will be identical to 'raw_subjects'! Further enrichment methods will
-    extend them with additional subjects.
+    'enriched_subjects' will be an empty array, to be extended with additional subjects.
 
     A record's subjects will be recognised if they exist in any of the structures defined in
     the various xpath() calls in the SQL query.  
@@ -917,7 +916,7 @@ def init_record_subjects() -> bool:
                 ) THEN
                     ALTER TABLE records ADD COLUMN raw_subjects text[];
                         -- add empty array as default value for new rows
-                    ALTER TABLE records ALTER COLUMN raw_subjects SET DEFAULT '{}';                        
+                    ALTER TABLE records ALTER COLUMN raw_subjects SET DEFAULT ARRAY[]::text[];                        
                 END IF;
                 END;
                 $$;
@@ -935,7 +934,7 @@ def init_record_subjects() -> bool:
                 ) THEN
                     ALTER TABLE records ADD COLUMN enriched_subjects text[];
                         -- add empty array as default value for new rows
-                    ALTER TABLE records ALTER COLUMN enriched_subjects SET DEFAULT '{}';       
+                    ALTER TABLE records ALTER COLUMN enriched_subjects SET DEFAULT ARRAY[]::text[];       
                 END IF;
                 END;
                 $$;
@@ -980,9 +979,7 @@ def init_record_subjects() -> bool:
                 )
                 UPDATE records a
                 SET
-                    raw_subjects = raw_subjects_extraction.subjects,
-                    -- the enriched field will start the same as raw, and then get expanded with more subjects later
-                    enriched_subjects = raw_subjects_extraction.subjects
+                    raw_subjects = raw_subjects_extraction.subjects
                 FROM raw_subjects_extraction
                 WHERE a.id = raw_subjects_extraction.id;
             """)

--- a/src/transform.py
+++ b/src/transform.py
@@ -639,112 +639,6 @@ def are_all_runs_closed_in_db() -> bool:
 
         return not result['has_open_runs']
 
-def init_record_subjects() -> bool:
-    """
-    Create 'raw_subjects' and 'enriched_subjects' fields in the record table.  
-    If the columns don't exist, they will be created.  
-    If they exist, they will be re-initialized. 'raw_subjects' is gathered from 'raw_metadata'.  
-    'enriched_subjects' will be identical to 'raw_subjects'! Further enrichment methods will
-    extend them with additional subjects.
-
-    A record's subjects will be recognised if they exist in any of the structures defined in
-    the various xpath() calls in the SQL query.  
-    The fields will be arrays of text values. So a record with no subjects will have an array length
-    of zero. Using array_to_string will concatenate them into a single string.
-
-    Returns
-    -------
-    bool
-        True if the initialization is completed successfuly.
-    """
-    with psycopg.connect(**connection_params, row_factory=dict_row) as conn:
-        cur = conn.cursor()
-
-        # Altering the records schema if the columns don't exist.
-        # If they exist, the queries don't change anything
-
-        # Column raw_subjects
-        cur.execute("""
-            DO $$
-            BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'records'
-                AND column_name = 'raw_subjects'
-            ) THEN
-                ALTER TABLE records ADD COLUMN raw_subjects text[];
-            END IF;
-            END;
-            $$;
-        """)
-
-        
-        # Column enriched_subjects
-        cur.execute("""
-            DO $$
-            BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'records'
-                AND column_name = 'enriched_subjects'
-            ) THEN
-                ALTER TABLE records ADD COLUMN enriched_subjects text[];
-            END IF;
-            END;
-            $$;
-        """)
-
-        # Fill the columns with subjects extracted from raw_metadata.
-        # Both column will have the same values!
-
-        cur.execute("""
-            WITH raw_subjects_extraction AS (
-                SELECT
-                    id,
-                    (
-                        xpath('oai:record/oai:metadata/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
-                            '{{datacite, http://datacite.org/schema/kernel-4},
-                            {oai, http://www.openarchives.org/OAI/2.0/}}'
-                        )::text[] ||
-                        xpath('oai:record/oai:metadata/oaidc:oai_datacite/oaidc:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
-                            '{{datacite, http://datacite.org/schema/kernel-4},
-                            {oai, http://www.openarchives.org/OAI/2.0/},
-                            {oaidc, http://schema.datacite.org/oai/oai-1.1/}}'
-                        )::text[] ||
-                        xpath('oai:record/oai:metadata/oai:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
-                            '{{datacite, http://datacite.org/schema/kernel-4},
-                            {oai, http://www.openarchives.org/OAI/2.0/}}'
-                        )::text[] ||
-                        xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
-                        -- note the 3 in datacite
-                            '{{datacite, http://datacite.org/schema/kernel-3},
-                            {oai, http://www.openarchives.org/OAI/2.0/},
-                            {oad, http://schema.datacite.org/oai/oai-1.0/}}'
-                        )::text[] ||
-                        -- same path as previous but uses kernel-4 namespace
-                        xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
-                            '{{datacite, http://datacite.org/schema/kernel-4},
-                            {oai, http://www.openarchives.org/OAI/2.0/},
-                            {oad, http://schema.datacite.org/oai/oai-1.0/}}'
-                        )::text[]
-                    ) AS subjects
-                FROM public.records
-            )
-            UPDATE records a
-            SET
-                raw_subjects = raw_subjects_extraction.subjects,
-                -- the enriched field will start the same as raw, and then get expanded with more subjects later
-                enriched_subjects = raw_subjects_extraction.subjects
-            FROM raw_subjects_extraction
-            WHERE a.id = raw_subjects_extraction.id;
-        """)
-                    
-
-        result = cur.fetchone()
-        if result is None:
-            raise RuntimeError('Query failed')
-
-        return True
 
 @app.get('/index', tags=['index'])
 def init_index(
@@ -981,3 +875,113 @@ def get_closed_runs(
     except Exception as e:
         logger.exception('Failed to fetch closed runs')
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get('/init_subjects', tags=['enrichment'], summary='Create initial raw_subjects and enriched_subjects.')
+def init_record_subjects() -> bool:
+    """
+    Create 'raw_subjects' and 'enriched_subjects' fields in the record table.  
+    If the columns don't exist, they will be created.  
+    If they exist, they will be re-initialized. 'raw_subjects' is gathered from 'raw_metadata'.  
+    'enriched_subjects' will be identical to 'raw_subjects'! Further enrichment methods will
+    extend them with additional subjects.
+
+    A record's subjects will be recognised if they exist in any of the structures defined in
+    the various xpath() calls in the SQL query.  
+    The fields will be arrays of text values. So a record with no subjects will have an array length
+    of zero. Using array_to_string will concatenate them into a single string.
+
+    Returns
+    -------
+    bool
+        True if the initialization is completed successfuly.
+    """
+    with psycopg.connect(**connection_params, row_factory=dict_row) as conn:
+        
+        try:
+            cur = conn.cursor()
+
+            # Altering the records schema if the columns don't exist.
+            # If they exist, the queries don't change anything
+
+            # Column raw_subjects
+            cur.execute("""
+                DO $$
+                BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'records'
+                    AND column_name = 'raw_subjects'
+                ) THEN
+                    ALTER TABLE records ADD COLUMN raw_subjects text[];
+                END IF;
+                END;
+                $$;
+            """)
+
+            
+            # Column enriched_subjects
+            cur.execute("""
+                DO $$
+                BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'records'
+                    AND column_name = 'enriched_subjects'
+                ) THEN
+                    ALTER TABLE records ADD COLUMN enriched_subjects text[];
+                END IF;
+                END;
+                $$;
+            """)
+
+            # Fill the columns with subjects extracted from raw_metadata.
+            # Both column will have the same values!
+
+            cur.execute("""
+                WITH raw_subjects_extraction AS (
+                    SELECT
+                        id,
+                        (
+                            xpath('oai:record/oai:metadata/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                                '{{datacite, http://datacite.org/schema/kernel-4},
+                                {oai, http://www.openarchives.org/OAI/2.0/}}'
+                            )::text[] ||
+                            xpath('oai:record/oai:metadata/oaidc:oai_datacite/oaidc:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                                '{{datacite, http://datacite.org/schema/kernel-4},
+                                {oai, http://www.openarchives.org/OAI/2.0/},
+                                {oaidc, http://schema.datacite.org/oai/oai-1.1/}}'
+                            )::text[] ||
+                            xpath('oai:record/oai:metadata/oai:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                                '{{datacite, http://datacite.org/schema/kernel-4},
+                                {oai, http://www.openarchives.org/OAI/2.0/}}'
+                            )::text[] ||
+                            xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                            -- note the 3 in datacite
+                                '{{datacite, http://datacite.org/schema/kernel-3},
+                                {oai, http://www.openarchives.org/OAI/2.0/},
+                                {oad, http://schema.datacite.org/oai/oai-1.0/}}'
+                            )::text[] ||
+                            -- same path as previous but uses kernel-4 namespace
+                            xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
+                                '{{datacite, http://datacite.org/schema/kernel-4},
+                                {oai, http://www.openarchives.org/OAI/2.0/},
+                                {oad, http://schema.datacite.org/oai/oai-1.0/}}'
+                            )::text[]
+                        ) AS subjects
+                    FROM public.records
+                )
+                UPDATE records a
+                SET
+                    raw_subjects = raw_subjects_extraction.subjects,
+                    -- the enriched field will start the same as raw, and then get expanded with more subjects later
+                    enriched_subjects = raw_subjects_extraction.subjects
+                FROM raw_subjects_extraction
+                WHERE a.id = raw_subjects_extraction.id;
+            """)
+
+            return True
+        
+        except Exception as e:
+            logger.exception('Failed to create raw_subjects and enriched_subjects')
+            raise HTTPException(status_code=500, detail=str(e))

--- a/src/transform.py
+++ b/src/transform.py
@@ -877,10 +877,10 @@ def get_closed_runs(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.post('/init_subjects', tags=['enrichment'], summary='Create initial raw_subjects and enriched_subjects.')
-def init_record_subjects() -> bool:
+@app.post('/init_subjects', tags=['enrichment'], summary='Create initial raw_subjects and empty enriched_subjects.')
+def init_record_subjects(from_date: str) -> bool:
     """
-    Initialize 'raw_subjects' and 'enriched_subjects' fields in the record table for all current records.
+    Initialize 'raw_subjects' and 'enriched_subjects' fields in the record table for records updated at or after the specified date.
 
     If the columns don't exist, they will be created.  
     If they exist, they will be re-initialized.  
@@ -891,7 +891,15 @@ def init_record_subjects() -> bool:
     the various xpath() calls in the SQL query.  
     The fields will be arrays of text values. So a record with no subjects will have an array length
     of zero. Use array_to_string() to concatenate them into a single string.
-
+    
+    Parameters
+    ----------
+    from_date : str to be converted into datetime.date
+        "%Y-%m-%d" format
+        Re-initialize record subjects for records whose "updated_at" date is equal or later than `from_date`.
+        So after new harvests we can initialize only recent records and not all in database.
+        To re-initialize all record set a date before any harvesting, e.g. "2020-01-01".
+    
     Returns
     -------
     bool
@@ -941,8 +949,14 @@ def init_record_subjects() -> bool:
             """)
             
 
+
             # Fill raw_subjects with subjects extracted from raw_metadata.
 
+            start_date = datetime.strptime(from_date, "%Y-%m-%d")
+
+            # For SQL: same format of date enclosed by single quotations
+            sql_date = "'" + start_date.strftime("%Y-%m-%d") + "'"
+            
             cur.execute("""
                 WITH raw_subjects_extraction AS (
                     SELECT
@@ -981,8 +995,10 @@ def init_record_subjects() -> bool:
                     raw_subjects = raw_subjects_extraction.subjects,
                     enriched_subjects = ARRAY[]::text[]
                 FROM raw_subjects_extraction
-                WHERE a.id = raw_subjects_extraction.id;
-            """)
+                WHERE a.id = raw_subjects_extraction.id
+                    AND a.updated_at::date >= %(start_date)s;
+            """,
+            {"start_date": sql_date})
 
             return True
         

--- a/src/transform.py
+++ b/src/transform.py
@@ -877,15 +877,15 @@ def get_closed_runs(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get('/init_subjects', tags=['enrichment'], summary='Create initial raw_subjects and enriched_subjects.')
+@app.post('/init_subjects', tags=['enrichment'], summary='Create initial raw_subjects and enriched_subjects.')
 def init_record_subjects() -> bool:
     """
-    Create 'raw_subjects' and 'enriched_subjects' fields in the record table.  
-    Fill them for all current records.
+    Initialize 'raw_subjects' and 'enriched_subjects' fields in the record table for all current records.
 
     If the columns don't exist, they will be created.  
-    If they exist, they will be re-initialized. 'raw_subjects' is gathered from 'raw_metadata'.  
-    'enriched_subjects' will be an empty array, to be extended with additional subjects.
+    If they exist, they will be re-initialized.  
+    'raw_subjects' will be filled based on 'raw_metadata'.  
+    'enriched_subjects' will be set to an empty array, to be extended with additional subjects.
 
     A record's subjects will be recognised if they exist in any of the structures defined in
     the various xpath() calls in the SQL query.  
@@ -978,7 +978,8 @@ def init_record_subjects() -> bool:
                 )
                 UPDATE records a
                 SET
-                    raw_subjects = raw_subjects_extraction.subjects
+                    raw_subjects = raw_subjects_extraction.subjects,
+                    enriched_subjects = ARRAY[]::text[]
                 FROM raw_subjects_extraction
                 WHERE a.id = raw_subjects_extraction.id;
             """)

--- a/src/transform.py
+++ b/src/transform.py
@@ -881,6 +881,8 @@ def get_closed_runs(
 def init_record_subjects() -> bool:
     """
     Create 'raw_subjects' and 'enriched_subjects' fields in the record table.  
+    Fill them for all current records.
+
     If the columns don't exist, they will be created.  
     If they exist, they will be re-initialized. 'raw_subjects' is gathered from 'raw_metadata'.  
     'enriched_subjects' will be identical to 'raw_subjects'! Further enrichment methods will
@@ -889,7 +891,7 @@ def init_record_subjects() -> bool:
     A record's subjects will be recognised if they exist in any of the structures defined in
     the various xpath() calls in the SQL query.  
     The fields will be arrays of text values. So a record with no subjects will have an array length
-    of zero. Using array_to_string will concatenate them into a single string.
+    of zero. Use array_to_string() to concatenate them into a single string.
 
     Returns
     -------
@@ -914,6 +916,8 @@ def init_record_subjects() -> bool:
                     AND column_name = 'raw_subjects'
                 ) THEN
                     ALTER TABLE records ADD COLUMN raw_subjects text[];
+                        -- add empty array as default value for new rows
+                    ALTER TABLE records ALTER COLUMN raw_subjects SET DEFAULT '{}';                        
                 END IF;
                 END;
                 $$;
@@ -930,10 +934,13 @@ def init_record_subjects() -> bool:
                     AND column_name = 'enriched_subjects'
                 ) THEN
                     ALTER TABLE records ADD COLUMN enriched_subjects text[];
+                        -- add empty array as default value for new rows
+                    ALTER TABLE records ALTER COLUMN enriched_subjects SET DEFAULT '{}';       
                 END IF;
                 END;
                 $$;
             """)
+            
 
             # Fill the columns with subjects extracted from raw_metadata.
             # Both column will have the same values!


### PR DESCRIPTION
Adds a new `init_subjects` POST endpoint to the transformer API.  
It takes a single `from_date` argument - raw_subjects and enriched_subjects will be updated for all records whose `updated_at` field is equal to or later than the given date. This way when new records are added the endpoint can initialize subjects for the newer records, without affecting older ones.    

`raw_subjects` is a text array where each element is a subject found in the record's `raw_metadata` field.  
`enriched_subjects` is an empty text array. This is meant to be filled in later, after specific methods of enrichment are implemented. This endpoint could also be used to reset this field to an empty array, if needed.  


All current records that have subjects *anywhere* in their raw_metadata XML conform to one of five xpaths:
```
xpath('oai:record/oai:metadata/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
                                '{{datacite, http://datacite.org/schema/kernel-4},
                                {oai, http://www.openarchives.org/OAI/2.0/}}'
                            )::text[] ||
                            xpath('oai:record/oai:metadata/oaidc:oai_datacite/oaidc:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
                                '{{datacite, http://datacite.org/schema/kernel-4},
                                {oai, http://www.openarchives.org/OAI/2.0/},
                                {oaidc, http://schema.datacite.org/oai/oai-1.1/}}'
                            )::text[] ||
                            xpath('oai:record/oai:metadata/oai:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
                                '{{datacite, http://datacite.org/schema/kernel-4},
                                {oai, http://www.openarchives.org/OAI/2.0/}}'
                            )::text[] ||
                            xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
                            -- note the 3 in datacite
                                '{{datacite, http://datacite.org/schema/kernel-3},
                                {oai, http://www.openarchives.org/OAI/2.0/},
                                {oad, http://schema.datacite.org/oai/oai-1.0/}}'
                            )::text[] ||
                            -- same path as previous but uses kernel-4 namespace
                            xpath('oai:record/oai:metadata/oad:oai_datacite/oad:payload/datacite:resource/datacite:subjects/datacite:subject/text()', raw_metadata,
                                '{{datacite, http://datacite.org/schema/kernel-4},
                                {oai, http://www.openarchives.org/OAI/2.0/},
                                {oad, http://schema.datacite.org/oai/oai-1.0/}}'
```

---

**Currently** this endpoint **alters** the records table to add `raw_subjects` and `enriched_subjects` fields if they are not already present.  
If the database design is altered to include those fields in the records table, I'll remove this part of the PR.