### PR TITLE
feat (swissubase): add analyzer for swissubase file metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "fastapi[standard]>=0.135.1",
     "psycopg[binary]>=3.3.3",
     # "flower", # only needed when not using mher/flower
-    "datahugger-ng>=0.6.2",
+    "datahugger-ng>=0.6.3",
     "docker>=7.1.0",
     "requests>=2.32.5",
     "lxml>=6.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,11 @@ dependencies = [
     "fastapi[standard]>=0.135.1",
     "psycopg[binary]>=3.3.3",
     # "flower", # only needed when not using mher/flower
-    "datahugger-ng>=0.6.1",
+    "datahugger-ng>=0.6.2",
     "docker>=7.1.0",
     "requests>=2.32.5",
     "lxml>=6.0.2",
 ]
-
 
 [dependency-groups]
 dev = [

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -184,7 +184,6 @@ def add_file_metadata(self: Any, batch: list[HarvestEventQueue]) -> int:
                 files.extend(self.collect_files(harvest_event, ds_dabar))
 
             elif harvest_event.code == ProviderCode.SWISSUBASE:
-                logger.debug(harvest_event.record_identifier)
                 ds_swiss = resolve(
                     f'https://www.swissubase.ch/en/catalogue/studies/1223/latest/datasets/114/{harvest_event.record_identifier}/overview'
                 )

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -11,14 +11,14 @@ from celery import Celery, Task
 from celery.signals import after_setup_logger
 from celery.utils.log import get_task_logger
 from datahugger import (
-    resolve,
     DabarXmlSrcDataset,
+    Dataset,
     DataverseJsonSrcDataset,
     FileEntry,
-    ZipEntry,
     HalJsonSrcDataset,
     ZenodoJsonSrcDataset,
-    Dataset
+    ZipEntry,
+    resolve,
 )
 from fastembed import TextEmbedding
 from jsonschema.validators import validate
@@ -130,7 +130,6 @@ class FileMetadataTask(Task):  # type: ignore
             None,
         )
 
-
     def collect_files(self, harvest_event: HarvestEventQueue, dataset: Dataset) -> list[tuple[Any, ...]]:
         return [self.make_file_entry(harvest_event, file) for file in dataset.crawl_file()]
 
@@ -186,7 +185,9 @@ def add_file_metadata(self: Any, batch: list[HarvestEventQueue]) -> int:
 
             elif harvest_event.code == ProviderCode.SWISSUBASE:
                 logger.debug(harvest_event.record_identifier)
-                ds_swiss = resolve(f'https://www.swissubase.ch/en/catalogue/studies/1223/latest/datasets/114/{harvest_event.record_identifier}/overview')
+                ds_swiss = resolve(
+                    f'https://www.swissubase.ch/en/catalogue/studies/1223/latest/datasets/114/{harvest_event.record_identifier}/overview'
+                )
 
                 for zip_file in ds_swiss.crawl():
                     files.append(self.make_zip_entry(harvest_event, zip_file))

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -92,7 +92,7 @@ class FileMetadataTask(Task):  # type: ignore
         checksum_type, checksum_value = self.parse_checksum(file)
 
         return (
-            harvest_event.harvest_url,  # harvest_url
+            harvest_event.harvest_url,
             harvest_event.record_identifier,
             file.file_identifier or file.filename,
             file.filename or file.file_identifier,
@@ -113,7 +113,7 @@ class FileMetadataTask(Task):  # type: ignore
         checksum_type, checksum_value = self.parse_checksum(zip_file)
 
         return (
-            harvest_event.harvest_url,  # harvest_url
+            harvest_event.harvest_url,
             harvest_event.record_identifier,
             harvest_event.record_identifier,
             harvest_event.record_identifier,

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -11,12 +11,13 @@ from celery import Celery, Task
 from celery.signals import after_setup_logger
 from celery.utils.log import get_task_logger
 from datahugger import (
+    resolve,
     DabarXmlSrcDataset,
-    Dataset,
     DataverseJsonSrcDataset,
     FileEntry,
     HalJsonSrcDataset,
     ZenodoJsonSrcDataset,
+    Dataset
 )
 from fastembed import TextEmbedding
 from jsonschema.validators import validate
@@ -67,6 +68,7 @@ class ProviderCode(str, Enum):
     ZENODO = 'ZENODO'
     HAL = 'HAL'
     DABAR = 'DABAR'
+    SWISSUBASE = 'SWISS'
 
 
 class FileMetadataTask(Task):  # type: ignore
@@ -159,8 +161,32 @@ def add_file_metadata(self: Any, batch: list[HarvestEventQueue]) -> int:
 
                 files.extend(self.collect_files(harvest_event, ds_dabar))
 
+            elif harvest_event.code == ProviderCode.SWISSUBASE:
+                logger.debug(harvest_event.record_identifier)
+                ds_swiss = resolve(f'https://www.swissubase.ch/en/catalogue/studies/1223/latest/datasets/114/{harvest_event.record_identifier}/overview')
+
+                for zip_file in ds_swiss.crawl():
+                    logger.debug(f'Zip: {zip_file.download_url}')
+                    files.append((
+                        harvest_event.harvest_url,  # harvest_url
+                        harvest_event.record_identifier,
+                        harvest_event.record_identifier,
+                        harvest_event.record_identifier,
+                        'datahugger',
+                        harvest_event.identifier_type,
+                        'Dataset',
+                        'application/zip',
+                        None,
+                        zip_file.checksum[0][0].upper(),
+                        zip_file.checksum[0][1],
+                        zip_file.version,
+                        zip_file.download_url,
+                        zip_file.creation_date,
+                        None,
+                    ))
+
             if len(files) == 0:
-                logger.debug(f'no files for {harvest_event.record_identifier}')
+                logger.debug(f'no files for {harvest_event.record_identifier} in {harvest_event.code}')
                 continue
             success += 1
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -15,6 +15,7 @@ from datahugger import (
     DabarXmlSrcDataset,
     DataverseJsonSrcDataset,
     FileEntry,
+    ZipEntry,
     HalJsonSrcDataset,
     ZenodoJsonSrcDataset,
     Dataset
@@ -78,7 +79,7 @@ class FileMetadataTask(Task):  # type: ignore
         # TODO: how to configure DB and not hard code?
         self.postgres_config = PostgresConfig(db=os.environ.get('FILE_DB'))
 
-    def parse_checksum(self, file: FileEntry) -> tuple[str | None, str | None]:
+    def parse_checksum(self, file: FileEntry | ZipEntry) -> tuple[str | None, str | None]:
         if not file.checksum:
             return None, None
 
@@ -107,6 +108,28 @@ class FileMetadataTask(Task):  # type: ignore
             file.creation_date,
             file.last_modification_date,
         )
+
+    def make_zip_entry(self, harvest_event: HarvestEventQueue, zip_file: ZipEntry) -> tuple[Any, ...]:
+        checksum_type, checksum_value = self.parse_checksum(zip_file)
+
+        return (
+            harvest_event.harvest_url,  # harvest_url
+            harvest_event.record_identifier,
+            harvest_event.record_identifier,
+            harvest_event.record_identifier,
+            'datahugger',
+            harvest_event.identifier_type,
+            'Dataset',
+            'application/zip',
+            None,
+            checksum_type,
+            checksum_value,
+            zip_file.version,
+            zip_file.download_url,
+            zip_file.creation_date,
+            None,
+        )
+
 
     def collect_files(self, harvest_event: HarvestEventQueue, dataset: Dataset) -> list[tuple[Any, ...]]:
         return [self.make_file_entry(harvest_event, file) for file in dataset.crawl_file()]
@@ -166,24 +189,7 @@ def add_file_metadata(self: Any, batch: list[HarvestEventQueue]) -> int:
                 ds_swiss = resolve(f'https://www.swissubase.ch/en/catalogue/studies/1223/latest/datasets/114/{harvest_event.record_identifier}/overview')
 
                 for zip_file in ds_swiss.crawl():
-                    logger.debug(f'Zip: {zip_file.download_url}')
-                    files.append((
-                        harvest_event.harvest_url,  # harvest_url
-                        harvest_event.record_identifier,
-                        harvest_event.record_identifier,
-                        harvest_event.record_identifier,
-                        'datahugger',
-                        harvest_event.identifier_type,
-                        'Dataset',
-                        'application/zip',
-                        None,
-                        zip_file.checksum[0][0].upper(),
-                        zip_file.checksum[0][1],
-                        zip_file.version,
-                        zip_file.download_url,
-                        zip_file.creation_date,
-                        None,
-                    ))
+                    files.append(self.make_zip_entry(harvest_event, zip_file))
 
             if len(files) == 0:
                 logger.debug(f'no files for {harvest_event.record_identifier} in {harvest_event.code}')

--- a/uv.lock
+++ b/uv.lock
@@ -267,20 +267,20 @@ wheels = [
 
 [[package]]
 name = "datahugger-ng"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/98/aefeca9f400a6df64289926065aea578c3bc11f50484bc8fd094beeec921/datahugger_ng-0.6.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:bd41acdf523afb689427676a4c896ff61fb9a693641f5fba0ede50dc44861090", size = 4213008, upload-time = "2026-05-26T08:31:36.539Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ad/ddceb99a9176825ac76fd94062a0760e8b1d22b0677c2c221b676eb44a20/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2b364667329dae1e8b7daa16c9b26a8c0bfabb454a9b27f984c62369e0d2a8d3", size = 6946507, upload-time = "2026-05-26T08:31:24.324Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/51/5c8a3e8c9aeca1af5c3f563d07e01eeb089e4d886a092b37ea0b9f122927/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:4724cc34fe72af6acffbbcf336603b1dd2e6ab957b9591183e8d74dcdacd2d36", size = 5854559, upload-time = "2026-05-26T08:31:26.752Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/d6/5d4d117f48881ea69622851c4b1ed3ea994afd9b9e26bb892d097bebfa9c/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:3e5ad014c711dfedc46d04c78762a2c3f67336dd715424886d790b632ce62696", size = 6173609, upload-time = "2026-05-26T08:31:31.498Z" },
-    { url = "https://files.pythonhosted.org/packages/69/e4/6c6824229200f7935b24a854b30c2014dd4cdbd806c9aa7792791381f39f/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:c0c8a62597d4b2fcbb7c9c36763009c8eba3297f2f47971f3e447ba5c05b7598", size = 7047571, upload-time = "2026-05-26T08:31:28.81Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/5c/0d143fcf19dccba8ff0da17d5cd9e0fbe98b914d3aa37723c36031122304/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1062ce2801bd44659c232d59747acbe71f44fe99b97229fb288208789903fca6", size = 6357488, upload-time = "2026-05-26T08:31:34.476Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/94/d1d29fab1168212021ddc07fc2df0b30c3a3ca30a4398f9ad098d6093e4d/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:642b468831440caf0542cd9d49283949b53c6d925db9498e1616ae5b98f29e50", size = 7297203, upload-time = "2026-05-26T08:31:38.641Z" },
-    { url = "https://files.pythonhosted.org/packages/79/65/3a0f3d4ee6b152f188198120c0f994f99c860616a40b0330dd696bf61965/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:5b0bd351eece7162c1cd606623d3facd601496393dee8e5fd708e01c4167c6dc", size = 6070550, upload-time = "2026-05-26T08:31:40.826Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/94/ba2b6cd2f8310a26b065651b1375c9670c2518d49e982d35ad6f4eb86c5d/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:2f4c7cb69fd50fcf30b476ab7b76e39c0e1b91c427621985430a4b6393961c3b", size = 6639332, upload-time = "2026-05-26T08:31:42.73Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/bb/cff7cd22203757a220ae95f78b9da1a463fca6382e781066d51da3ec21b2/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b55121b01010c8fa31f719c2917a0828d9108d743ad601d4a9d490b4c28e134", size = 7173317, upload-time = "2026-05-26T08:31:44.588Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/a3/c3acdac5419c362e206d4da27fe0ce5beaae599e6bc87032bf91c5811fbe/datahugger_ng-0.6.2-cp310-abi3-win_amd64.whl", hash = "sha256:131df0527ea8ffad2f09d7e0faf4a2bab7a69419f283a0d10eff0569a8655942", size = 3667034, upload-time = "2026-05-26T08:31:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/03/47/ae97aaa17ca2ffb982fdfe4d21926841e6217800c3dd4a4393a0d03a4e66/datahugger_ng-0.6.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:39af5757897ae0bebbea70ee1b35afcdcb828f180750214127035061c519a36a", size = 4211819, upload-time = "2026-05-27T12:46:20.712Z" },
+    { url = "https://files.pythonhosted.org/packages/94/9e/c2c824ecf192520c7677af372a148006e5fb5bf136965f082105fb4be959/datahugger_ng-0.6.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:62227f4e5fd75161913963914b7dc7784af72e5f1b9405a869272dca190bc64d", size = 6947524, upload-time = "2026-05-27T12:46:11.82Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ea/2b89621ff71e4f40ab19b7dcf4148888912cb4de65c028116fa0419e3008/datahugger_ng-0.6.3-cp310-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:c5bad63320191672b8cd76ee5bde6db28150d9135ab5d3caf7fa5bdf12d783c9", size = 5854124, upload-time = "2026-05-27T12:46:13.612Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8a/3909af94038f3638b93825f9bee259a6fd8ba37109024483637f3694e6ea/datahugger_ng-0.6.3-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:7e7d9a4a37897c59f72439ba9b11c021c04e3323a04fa80e32ac7f6d64fcdbd1", size = 6173373, upload-time = "2026-05-27T12:46:17.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/43/b930cb168ebf998ba97c537aa64243a73d50ab16f698a9e0229402a28ee5/datahugger_ng-0.6.3-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:1253e890b9704b5174b163a102503d82ecd48c03fd29ec3fc37384487ab8bb91", size = 7048048, upload-time = "2026-05-27T12:46:15.771Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9d/3000b581e69394043b3ff564cc0e6d03620d74fb6c8efe53a0d8ad607208/datahugger_ng-0.6.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9dea6c333ea68ca93efaedf90c35c528bb1f80c69565cda2f62dce06874dd7f4", size = 6357787, upload-time = "2026-05-27T12:46:19.273Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f2/e109cdfb4da78bbd2dbd1b44dfedd8d2a7b04134c3d5d60673dcdee1684a/datahugger_ng-0.6.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8fecf587af80e3e0477765e8cf656c79af1ab9ad039d8e61263297a5b96d8616", size = 7296872, upload-time = "2026-05-27T12:46:22.468Z" },
+    { url = "https://files.pythonhosted.org/packages/04/07/117625398ae5feb13eef3e2f93d8055879983ba701ee75d70977b3815bdc/datahugger_ng-0.6.3-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:aee1408dd57a602cf245dacd327a4f8b98878a7a3ec1a0124584e9581d8a3f4e", size = 6069724, upload-time = "2026-05-27T12:46:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/70/6268ca195ccaf773d20379cc0c0592d54ad49e9aa684d172e882e6c752b0/datahugger_ng-0.6.3-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:099fe03b5ca24babe5ea6992bfa53566e55e10fbcaefd183bc874216a933f27c", size = 6638758, upload-time = "2026-05-27T12:46:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fd/e6cdf8acebbb770d6d021bf002d630761f00866cbe0fb6246f697419beb4/datahugger_ng-0.6.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:afc6f70890c64ef43ae55c4fdc14e463df731238bbe39ed36b0f6a10c5441f4d", size = 7173487, upload-time = "2026-05-27T12:46:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e5/b85521a7b6d832a18b1e38124ad1dceab4b0a67e9ce1cf0aa21fd42d3e70/datahugger_ng-0.6.3-cp310-abi3-win_amd64.whl", hash = "sha256:f4d99f8112f72a13ac7321e27df3332c59e905fdb04dcfdb276406bbf96410a3", size = 3667544, upload-time = "2026-05-27T12:46:29.381Z" },
 ]
 
 [[package]]
@@ -1031,7 +1031,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.6.2" },
-    { name = "datahugger-ng", specifier = ">=0.6.2" },
+    { name = "datahugger-ng", specifier = ">=0.6.3" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.1" },
     { name = "fastembed", specifier = ">=0.7.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,18 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
+[options.exclude-newer-package]
+datahugger-ng = false
 
 [[package]]
 name = "amqp"
@@ -260,20 +267,20 @@ wheels = [
 
 [[package]]
 name = "datahugger-ng"
-version = "0.6.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/0c/d3b340ceef3884ab699bbcdb61b79d0f3c39e1ee665402d908448fab2ce8/datahugger_ng-0.6.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8ffc412463c0efadfc6f9aaf89ace5db6539ced2b785a9c19b751a4b3bfa05e2", size = 4156501, upload-time = "2026-04-24T08:18:12.744Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/3f/9072799816acde7b1a79705b1dfcd937974abfeb50fa611019267eba355b/datahugger_ng-0.6.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bd04f9b7cd94a825e804027edfa1dc4c1cb2c6aa27efee2c72d19f97e1f9578a", size = 6881477, upload-time = "2026-04-24T08:17:42.93Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5f/3cefed95aeaae53e3e98a9569138d656f0f2ab96c0a8a07187e3e94d4565/datahugger_ng-0.6.1-cp310-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:cda787e2cb90498449693c05790fef416599a789f7223a63d906d8b7a20585d6", size = 5791052, upload-time = "2026-04-24T08:17:45.219Z" },
-    { url = "https://files.pythonhosted.org/packages/95/63/54fa8fa0c9cd2e49fb8002be55cc247ab65cae307831453959ebb2e1bf6d/datahugger_ng-0.6.1-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:8a16ad8569d3f35a17b3de0c7c4aec843bfdb166c5aad84c675bb30d514e79e8", size = 6112484, upload-time = "2026-04-24T08:17:49.578Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/79/223081dbcec802c6962f8394a6727e12625a3889a483d6870934b3e01ce5/datahugger_ng-0.6.1-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:bc4f3f85a7d742264c3dacfab930eb7f5d74f2c126bddb96d619af9e48df0803", size = 6967377, upload-time = "2026-04-24T08:17:47.527Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/b2/45bf5fb067bcc6d3578c1e1b11c224a7ca5eab91c26d57169926d58ecdae/datahugger_ng-0.6.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9245f90b9450419083938b225a79217b5baaae2da78d90ab71322031051cdf23", size = 6299164, upload-time = "2026-04-24T08:17:51.449Z" },
-    { url = "https://files.pythonhosted.org/packages/02/69/2a4f51cc0f7d446eeb4df06e88b23a4fdf40a2ed93d258549aa22069c765/datahugger_ng-0.6.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:552af9309363dadf9644dd18f4926b40bfc071ee855cc57cf8e154eff9d46f4d", size = 7231088, upload-time = "2026-04-24T08:18:14.844Z" },
-    { url = "https://files.pythonhosted.org/packages/93/1b/e51f59d628af1fda1c88011a99eea0c9714bb318a97979357562448f0a9c/datahugger_ng-0.6.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:792e85e48224fa4f9267b50a77b2e95212b13ca0bacee89a227f63c7044cdab2", size = 6003925, upload-time = "2026-04-24T08:18:16.78Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/03/c9b7e13722767167f234efd1ac8147cdc6f5110c779729d9dbff3230b32c/datahugger_ng-0.6.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:970c4a9e3d3df1709876bfd2597d34d7d5fc45411c715d2d9b8625b4596870d4", size = 6585436, upload-time = "2026-04-24T08:18:18.954Z" },
-    { url = "https://files.pythonhosted.org/packages/18/9f/f8424d39f91c1e2c6e5ff48fe8b82a344849097a4328fee48851082ef351/datahugger_ng-0.6.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:69ed7d9bdb171fd85d74ab1b2ad6f1fd003bcebd6428221c7e4deec4990db60f", size = 7106168, upload-time = "2026-04-24T08:18:20.921Z" },
-    { url = "https://files.pythonhosted.org/packages/13/90/049104a07935d3681d75dfcb30c35ae4db95e74315d6a95313cdec4eb148/datahugger_ng-0.6.1-cp310-abi3-win_amd64.whl", hash = "sha256:7c582c7676b3610f89f2d6199346ba8f6e9c0c29dd7c0c3a98d18d74f0d98a40", size = 3600759, upload-time = "2026-04-24T08:18:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/13/98/aefeca9f400a6df64289926065aea578c3bc11f50484bc8fd094beeec921/datahugger_ng-0.6.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:bd41acdf523afb689427676a4c896ff61fb9a693641f5fba0ede50dc44861090", size = 4213008, upload-time = "2026-05-26T08:31:36.539Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ad/ddceb99a9176825ac76fd94062a0760e8b1d22b0677c2c221b676eb44a20/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2b364667329dae1e8b7daa16c9b26a8c0bfabb454a9b27f984c62369e0d2a8d3", size = 6946507, upload-time = "2026-05-26T08:31:24.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/51/5c8a3e8c9aeca1af5c3f563d07e01eeb089e4d886a092b37ea0b9f122927/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:4724cc34fe72af6acffbbcf336603b1dd2e6ab957b9591183e8d74dcdacd2d36", size = 5854559, upload-time = "2026-05-26T08:31:26.752Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/d6/5d4d117f48881ea69622851c4b1ed3ea994afd9b9e26bb892d097bebfa9c/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:3e5ad014c711dfedc46d04c78762a2c3f67336dd715424886d790b632ce62696", size = 6173609, upload-time = "2026-05-26T08:31:31.498Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e4/6c6824229200f7935b24a854b30c2014dd4cdbd806c9aa7792791381f39f/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:c0c8a62597d4b2fcbb7c9c36763009c8eba3297f2f47971f3e447ba5c05b7598", size = 7047571, upload-time = "2026-05-26T08:31:28.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5c/0d143fcf19dccba8ff0da17d5cd9e0fbe98b914d3aa37723c36031122304/datahugger_ng-0.6.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1062ce2801bd44659c232d59747acbe71f44fe99b97229fb288208789903fca6", size = 6357488, upload-time = "2026-05-26T08:31:34.476Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/94/d1d29fab1168212021ddc07fc2df0b30c3a3ca30a4398f9ad098d6093e4d/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:642b468831440caf0542cd9d49283949b53c6d925db9498e1616ae5b98f29e50", size = 7297203, upload-time = "2026-05-26T08:31:38.641Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/3a0f3d4ee6b152f188198120c0f994f99c860616a40b0330dd696bf61965/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:5b0bd351eece7162c1cd606623d3facd601496393dee8e5fd708e01c4167c6dc", size = 6070550, upload-time = "2026-05-26T08:31:40.826Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/94/ba2b6cd2f8310a26b065651b1375c9670c2518d49e982d35ad6f4eb86c5d/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:2f4c7cb69fd50fcf30b476ab7b76e39c0e1b91c427621985430a4b6393961c3b", size = 6639332, upload-time = "2026-05-26T08:31:42.73Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bb/cff7cd22203757a220ae95f78b9da1a463fca6382e781066d51da3ec21b2/datahugger_ng-0.6.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b55121b01010c8fa31f719c2917a0828d9108d743ad601d4a9d490b4c28e134", size = 7173317, upload-time = "2026-05-26T08:31:44.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a3/c3acdac5419c362e206d4da27fe0ce5beaae599e6bc87032bf91c5811fbe/datahugger_ng-0.6.2-cp310-abi3-win_amd64.whl", hash = "sha256:131df0527ea8ffad2f09d7e0faf4a2bab7a69419f283a0d10eff0569a8655942", size = 3667034, upload-time = "2026-05-26T08:31:46.636Z" },
 ]
 
 [[package]]
@@ -1024,7 +1031,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.6.2" },
-    { name = "datahugger-ng", specifier = ">=0.6.1" },
+    { name = "datahugger-ng", specifier = ">=0.6.2" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.1" },
     { name = "fastembed", specifier = ">=0.7.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -7,13 +7,6 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
-
-[options.exclude-newer-package]
-datahugger-ng = false
-
 [[package]]
 name = "amqp"
 version = "5.3.1"


### PR DESCRIPTION
Analyze SwissUbase metadata and write to `filedb`.

Datahugger already supports reading zip files' contents but for now now, only one entry per zip file is written to `filedb`. I wonder whether we'd have a file concept in `filedb` although those files could only be downloaded as part of a zip. Also SwissUBase puts restrictions on certain zips so not all of them can be downloaded.