### PR TITLE
feat (datacite json): add alternate identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ In development, it may be more convenient to load pre-harvested static data:
 - transform data from `scripts/postgres_data/data` to a local dir
   (to test transformation, alternative to using the Celery process):
   ```sh
-  uv run transform.py -i harvests_{repo_suffix} -o {repo_suffix}_json -s JSON_schema_file [-n]
+  uv run transform.py -i harvests_{repo_suffix} -o {repo_suffix}_json -s JSON_schema_file [-n] [-v]
   ```
-  If the -n flag is provided, the JSON data will also be normalized and validated against the JSON schema file `utils/schema.json`.
+  If the -n flag is provided, the JSON data will be normalized 
+  (the raw JSON may look differently based on the input XML, see these [specs](https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html])).
+  If the -v flag is set, the JSON will be validated against the JSON schema file `utils/schema.json`
 
 ## Create OpenSearch Index
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In development, it may be more convenient to load pre-harvested static data:
   uv run transform.py -i harvests_{repo_suffix} -o {repo_suffix}_json -s JSON_schema_file [-n] [-v]
   ```
   If the -n flag is provided, the JSON data will be normalized 
-  (the raw JSON may look differently based on the input XML, see these [specs](https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html])).
+  (the raw JSON may look differently based on the input XML, see these [specs](https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html)).
   If the -v flag is set, the JSON will be validated against the JSON schema file `utils/schema.json`
 
 ## Create OpenSearch Index

--- a/config/schema.json
+++ b/config/schema.json
@@ -99,6 +99,22 @@
                 "additionalProperties": false
             }
         },
+        "alternateIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "properties": {
+                        "alternateIdentifier": {
+                            "type": "string"
+                        },
+                        "alternateIdentifierType": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "publicationYear": {
             "type": "string",
             "pattern": "^[0-9]{4}$"

--- a/config/schema.json
+++ b/config/schema.json
@@ -104,15 +104,17 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "properties": {
-                        "alternateIdentifier": {
-                            "type": "string"
-                        },
-                        "alternateIdentifierType": {
-                            "type": "string"
-                        }
+                    "alternateIdentifier": {
+                        "type": "string"
+                    },
+                    "alternateIdentifierType": {
+                        "type": "string"
                     }
-                }
+                },
+                "required": [
+                    "alternateIdentifier"
+                ],
+                "additionalProperties": false
             }
         },
         "publicationYear": {
@@ -173,8 +175,8 @@
                 }
             },
             "required": [
-                    "resourceTypeGeneral"
-                ],
+                "resourceTypeGeneral"
+            ],
             "additionalProperties": false
         },
         "formats": {

--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -194,7 +194,7 @@ INSERT INTO endpoints (repository_id, name, harvest_url, protocol, scientific_di
 SELECT
     r.id,
     'FinBIF',
-    'https://api.laji.fi',
+    'https://api.gbif.org',
     'FINBIF_API',
     'Biology',
     true,

--- a/src/utils/normalize_datacite_json.py
+++ b/src/utils/normalize_datacite_json.py
@@ -319,7 +319,8 @@ def normalize_datacite_json(res: dict[str, Any], datacite_schema: str) -> dict[s
                     make_array(res.get(f'{datacite_schema}:creators'), f'{datacite_schema}:creator'),
                 )
             ),
-            'alternateIdentifiers': list(map(
+            'alternateIdentifiers': list(
+                map(
                     lambda el: harmonize_props(
                         el,
                         f'{datacite_schema}:alternateIdentifier',
@@ -327,8 +328,11 @@ def normalize_datacite_json(res: dict[str, Any], datacite_schema: str) -> dict[s
                         {},
                         datacite_schema,
                     ),
-                    make_array(res.get(f'{datacite_schema}:alternateIdentifiers'), f'{datacite_schema}:alternateIdentifier'),
-                )),
+                    make_array(
+                        res.get(f'{datacite_schema}:alternateIdentifiers'), f'{datacite_schema}:alternateIdentifier'
+                    ),
+                )
+            ),
             'publicationYear': res.get(f'{datacite_schema}:publicationYear'),
             'descriptions': list(
                 map(

--- a/src/utils/normalize_datacite_json.py
+++ b/src/utils/normalize_datacite_json.py
@@ -319,6 +319,16 @@ def normalize_datacite_json(res: dict[str, Any], datacite_schema: str) -> dict[s
                     make_array(res.get(f'{datacite_schema}:creators'), f'{datacite_schema}:creator'),
                 )
             ),
+            'alternateIdentifiers': list(map(
+                    lambda el: harmonize_props(
+                        el,
+                        f'{datacite_schema}:alternateIdentifier',
+                        {'@alternateIdentifierType': 'alternateIdentifierType'},
+                        {},
+                        datacite_schema,
+                    ),
+                    make_array(res.get(f'{datacite_schema}:alternateIdentifiers'), f'{datacite_schema}:alternateIdentifier'),
+                )),
             'publicationYear': res.get(f'{datacite_schema}:publicationYear'),
             'descriptions': list(
                 map(


### PR DESCRIPTION
This PR adds support for the inclusion of `alternateIdentifiers` in DataCite JSON.

Related PR: https://github.com/EOSC-Data-Commons/metadata-crawlers/pull/32

Migration query:

```sql
UPDATE endpoints
SET harvest_url = 'https://api.gbif.org'
WHERE name = 'FinBIF'
  AND repository_id = (SELECT id FROM repositories WHERE code = 'FINBIF');
```