### PR TITLE
feat(skip embedding calc): add flag to skip recalculating embeddings

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -349,39 +349,37 @@ def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, 
                 continue
 
         try:
+            src_with_emb: list[OpenSearchSourceWithEmbedding] = []
             if reuse_embeddings:
                 logger.info(f'Reusing embeddings from DB for {len(normalized)} records')
-                src_with_emb: list[OpenSearchSourceWithEmbedding] = []
-                for ele in normalized:
+                for normalized_ele in normalized:
                     cur.execute(
                         """
                         SELECT embeddings FROM records
                         WHERE endpoint_id = %s AND record_identifier = %s
                         """,
-                        (ele.event.endpoint_id, ele.event.record_identifier),
+                        (normalized_ele.event.endpoint_id, normalized_ele.event.record_identifier),
                     )
                     row = cur.fetchone()
                     if row is None:
                         raise ValueError(
-                            f'No existing embeddings found for {ele.event.record_identifier} on endpoint {ele.event.endpoint_id}'
+                            f'No existing embeddings found for {normalized_ele.event.record_identifier} on endpoint {normalized_ele.event.endpoint_id}'
                         )
                     src_with_emb.append(
                         OpenSearchSourceWithEmbedding(
                             src={
-                                **ele.src,
+                                **normalized_ele.src,
                                 'emb': row['embeddings'],
-                                '_additional_metadata': ele.event.additional_metadata,
-                                '_repo': ele.event.code,
-                                '_harvest_url': ele.event.harvest_url,
+                                '_additional_metadata': normalized_ele.event.additional_metadata,
+                                '_repo': normalized_ele.event.code,
+                                '_harvest_url': normalized_ele.event.harvest_url,
                             },
-                            harvest_event=ele.event,
+                            harvest_event=normalized_ele.event,
                         )
                     )
             else:
                 logger.info(f'About to Calculate embeddings for {len(normalized)}')
-                src_with_emb: list[OpenSearchSourceWithEmbedding] = add_embeddings_to_source(
-                    normalized, self.embedding_transformer
-                )
+                src_with_emb = add_embeddings_to_source(normalized, self.embedding_transformer)
                 logger.info(f'Calculated embeddings for {len(src_with_emb)}')
             preprocessed = preprocess_batch([src_with_emb_ele.src for src_with_emb_ele in src_with_emb], index_name)
         except Exception as e:

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -414,33 +414,44 @@ def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, 
                 # https://neon.com/postgresql/postgresql-tutorial/postgresql-upsert
                 cur.execute(
                     """
-                INSERT INTO records 
-                (   
-                    record_identifier,
-                    repository_id,
-                    endpoint_id,
-                    resource_type,
-                    title,
-                    raw_metadata,
-                    metadata_protocol,
-                    doi,
-                    url,
-                    embeddings,
-                    embedding_model,
-                    datacite_json,
-                    opensearch_synced,
-                    opensearch_synced_at,
-                    additional_metadata,
-                    datestamp
+                    INSERT INTO records 
+                    (   
+                        record_identifier,
+                        repository_id,
+                        endpoint_id,
+                        resource_type,
+                        title,
+                        raw_metadata,
+                        metadata_protocol,
+                        doi,
+                        url,
+                        embeddings,
+                        embedding_model,
+                        datacite_json,
+                        opensearch_synced,
+                        opensearch_synced_at,
+                        additional_metadata,
+                        datestamp
                     ) 
-                VALUES (
-                    %s, %s, %s, %s, %s, XMLPARSE(DOCUMENT %s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    VALUES (
+                        %s, %s, %s, %s, %s, XMLPARSE(DOCUMENT %s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
                     )
                     ON CONFLICT (endpoint_id, record_identifier)
-                    DO UPDATE SET resource_type = %s, title = %s, raw_metadata = XMLPARSE(DOCUMENT %s), doi = %s, url = %s, embeddings = %s, embedding_model = %s, datacite_json = %s, opensearch_synced_at = %s, additional_metadata = %s, datestamp = %s      
-                """,
+                    DO UPDATE SET 
+                        resource_type = EXCLUDED.resource_type,
+                        title = EXCLUDED.title,
+                        raw_metadata = EXCLUDED.raw_metadata,
+                        doi = EXCLUDED.doi,
+                        url = EXCLUDED.url,
+                        embeddings = EXCLUDED.embeddings,
+                        embedding_model = EXCLUDED.embedding_model,
+                        datacite_json = EXCLUDED.datacite_json,
+                        opensearch_synced_at = EXCLUDED.opensearch_synced_at,
+                        additional_metadata = EXCLUDED.additional_metadata,
+                        datestamp = EXCLUDED.datestamp
+                    """,
                     (
-                        record_identifier,  # Insert
+                        record_identifier,
                         repository_id,
                         endpoint_id,
                         resource_type,
@@ -453,17 +464,6 @@ def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, 
                         EMBEDDING_MODEL,
                         datacite_json,
                         opensearch_synced,
-                        opensearch_synced_at,
-                        additional_metadata,
-                        datestamp,
-                        resource_type,  # Update
-                        title,
-                        xml,
-                        doi,
-                        url,
-                        embeddings,
-                        EMBEDDING_MODEL,
-                        datacite_json,
                         opensearch_synced_at,
                         additional_metadata,
                         datestamp,

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -234,7 +234,7 @@ class TransformTask(Task):  # type: ignore
 
 
 @celery_app.task(base=TransformTask, bind=True, ignore_result=True)
-def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, reuse_embeddings: bool = False) -> Any:
+def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, reuse_embeddings: bool) -> Any:
     if not self.client.indices.exists(index=index_name):
         raise ValueError(f'Index {index_name} does not exist in OpenSearch')
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -363,12 +363,17 @@ def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, 
                     row = cur.fetchone()
                     if row is None:
                         raise ValueError(
-                            f'No existing embeddings found for {ele.event.record_identifier} on endpoint {ele.event.endpoint_id}')
+                            f'No existing embeddings found for {ele.event.record_identifier} on endpoint {ele.event.endpoint_id}'
+                        )
                     src_with_emb.append(
                         OpenSearchSourceWithEmbedding(
-                            src={**ele.src, 'emb': row['embeddings'],
-                                 '_additional_metadata': ele.event.additional_metadata, '_repo': ele.event.code,
-                                 '_harvest_url': ele.event.harvest_url},
+                            src={
+                                **ele.src,
+                                'emb': row['embeddings'],
+                                '_additional_metadata': ele.event.additional_metadata,
+                                '_repo': ele.event.code,
+                                '_harvest_url': ele.event.harvest_url,
+                            },
                             harvest_event=ele.event,
                         )
                     )

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -234,7 +234,7 @@ class TransformTask(Task):  # type: ignore
 
 
 @celery_app.task(base=TransformTask, bind=True, ignore_result=True)
-def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str) -> Any:
+def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str, reuse_embeddings: bool = False) -> Any:
     if not self.client.indices.exists(index=index_name):
         raise ValueError(f'Index {index_name} does not exist in OpenSearch')
 
@@ -349,11 +349,35 @@ def transform_batch(self: Any, batch: list[HarvestEventQueue], index_name: str) 
                 continue
 
         try:
-            logger.info(f'About to Calculate embeddings for {len(normalized)}')
-            src_with_emb: list[OpenSearchSourceWithEmbedding] = add_embeddings_to_source(
-                normalized, self.embedding_transformer
-            )
-            logger.info(f'Calculated embeddings for {len(src_with_emb)}')
+            if reuse_embeddings:
+                logger.info(f'Reusing embeddings from DB for {len(normalized)} records')
+                src_with_emb: list[OpenSearchSourceWithEmbedding] = []
+                for ele in normalized:
+                    cur.execute(
+                        """
+                        SELECT embeddings FROM records
+                        WHERE endpoint_id = %s AND record_identifier = %s
+                        """,
+                        (ele.event.endpoint_id, ele.event.record_identifier),
+                    )
+                    row = cur.fetchone()
+                    if row is None:
+                        raise ValueError(
+                            f'No existing embeddings found for {ele.event.record_identifier} on endpoint {ele.event.endpoint_id}')
+                    src_with_emb.append(
+                        OpenSearchSourceWithEmbedding(
+                            src={**ele.src, 'emb': row['embeddings'],
+                                 '_additional_metadata': ele.event.additional_metadata, '_repo': ele.event.code,
+                                 '_harvest_url': ele.event.harvest_url},
+                            harvest_event=ele.event,
+                        )
+                    )
+            else:
+                logger.info(f'About to Calculate embeddings for {len(normalized)}')
+                src_with_emb: list[OpenSearchSourceWithEmbedding] = add_embeddings_to_source(
+                    normalized, self.embedding_transformer
+                )
+                logger.info(f'Calculated embeddings for {len(src_with_emb)}')
             preprocessed = preprocess_batch([src_with_emb_ele.src for src_with_emb_ele in src_with_emb], index_name)
         except Exception as e:
             logger.error(f'Could not calculate embeddings: {e}')

--- a/src/transform.py
+++ b/src/transform.py
@@ -498,12 +498,13 @@ JOIN repositories r ON e.repository_id = r.id
         raise HTTPException(status_code=500, detail=str(e))
 
 
-def create_jobs_in_queue(harvest_run_id: str, index_name: str) -> int:
+def create_jobs_in_queue(harvest_run_id: str, index_name: str, reuse_embeddings: bool) -> int:
     """
     Creates and enqueues transformation jobs from harvest_events table.
 
     :param harvest_run_id: ID of the harvest run the harvest events belong to.
     :param index_name: Name of the OpenSearch index to use.
+    :param reuse_embeddings: Reuse existing embeddings instead of recalculation.
     :return: Number of batches scheduled for processing.
     """
 
@@ -582,7 +583,7 @@ def create_jobs_in_queue(harvest_run_id: str, index_name: str) -> int:
 
             # https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#keeping-results
             logger.info(f'Putting batch of {len(batch)} in queue with offset {offset}')
-            transform_batch.delay(batch, index_name)
+            transform_batch.delay(batch, index_name, reuse_embeddings)
             add_file_metadata.delay(batch)
             tasks += 1
 
@@ -644,11 +645,12 @@ def are_all_runs_closed_in_db() -> bool:
 def init_index(
     harvest_run_id: str = Query(default=None, description='Id of the harvest run to be indexed'),
     index_name: str = Query(default=None, description='Name of the OpenSearch index to use for indexing'),
+    reuse_embeddings: bool = Query(default=False, description='Whether to reuse embeddings or not'),
 ) -> IndexGetResponse:
     # this long-running method is synchronous and runs in an external threadpool, see https://fastapi.tiangolo.com/async/#path-operation-functions
     # this way, it does not block the server
     try:
-        results = create_jobs_in_queue(harvest_run_id, index_name)
+        results = create_jobs_in_queue(harvest_run_id, index_name, reuse_embeddings)
     except Exception as e:
         logger.exception('Indexing failed')
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
This PR adds an optimization to leave out recalculating embeddings when reindexing with JSON format changes.This way, expensive recalculation of essentially the same embeddings can be avoided. Note that this requires a previously successful embedding calculation. 