### PR TITLE
chore(gh actions): update packages

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,9 +11,9 @@ jobs:
         env:
             UV_PYTHON: ${{ matrix.python-version }}
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Install uv
-                uses: astral-sh/setup-uv@v6
+                uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
             -   name: Install the project
                 run: uv sync --all-extras --group dev # https://docs.astral.sh/uv/guides/integration/github/#syncing-and-running
             -   name: Test with pytest
@@ -34,7 +34,7 @@ jobs:
         env:
             UV_PYTHON: ${{ matrix.python-version }}
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
 
             -   name: Docker Build
                 run: docker compose build
@@ -56,7 +56,7 @@ jobs:
                     timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U admin; do sleep 2; done'
 
             -   name: Install uv
-                uses: astral-sh/setup-uv@v6
+                uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
             -   name: Install the project
                 run: uv sync --all-extras --dev

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: '3.12'
       - run: uv tool install conventional-pre-commit

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix warnings related to old node version:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, astral-sh/setup-uv@v6. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/