### PR TITLE
fix(docker): copy uv.lock and use --frozen

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,7 +15,7 @@ jobs:
             -   name: Install uv
                 uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
             -   name: Install the project
-                run: uv sync --all-extras --group dev # https://docs.astral.sh/uv/guides/integration/github/#syncing-and-running
+                run: uv sync --frozen --all-extras --group dev # https://docs.astral.sh/uv/guides/integration/github/#syncing-and-running
             -   name: Test with pytest
                 run: uv run pytest tests
             -   name: Check root mypy
@@ -59,7 +59,7 @@ jobs:
                 uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
             -   name: Install the project
-                run: uv sync --all-extras --dev
+                run: uv sync --frozen --all-extras --dev
 
             -   name: Test with pytest
                 run: uv run pytest -s e2e

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To run the containers:
   ```
 - Install [uv](https://docs.astral.sh/uv/) and run
   ```sh
-  uv sync
+  uv sync --frozen
   ```
 
 ## Prepare Data For Local Import
@@ -220,8 +220,9 @@ uv run pytest -s e2e
 ## Commit Message Conventions
 
 Keep to this commit message [style](https://www.conventionalcommits.org/en/v1.0.0/#summary). 
+For semantic versioning, see these [release-please](https://github.com/googleapis/release-please#how-should-i-write-my-commits).
 Set up pre-commit hooks to check your messages before commiting them to the repo:
-- `uv sync --all-extras --dev`
+- `uv sync --frozen --all-extras --dev`
 - `uv run pre-commit install --hook-type commit-msg`
 
 See `.pre-commit-config.yaml` for further details.

--- a/docker/scheduler/Dockerfile
+++ b/docker/scheduler/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 WORKDIR /app
 
 COPY pyproject.toml uv.lock* ./
-RUN uv sync --no-dev
+RUN uv sync --frozen --no-dev
 
 RUN apt-get update && \
     apt-get install -y docker.io docker-compose

--- a/docker/transform/Dockerfile
+++ b/docker/transform/Dockerfile
@@ -1,7 +1,6 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
-COPY ./pyproject.toml /code/pyproject.toml
-COPY ./uv.lock /code/uv.lock
+COPY ./pyproject.toml ./uv.lock /code/
 
 WORKDIR /code/src
 

--- a/docker/transform/Dockerfile
+++ b/docker/transform/Dockerfile
@@ -2,8 +2,12 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 COPY ./pyproject.toml ./uv.lock /code/
 
-WORKDIR /code/src
-
+WORKDIR /code
 ENV UV_LINK_MODE=copy
 RUN uv sync --frozen --no-dev
+
+COPY ./src /code/src
+COPY ./config /code/config
+
+WORKDIR /code/src
 ENV PATH="/code/.venv/bin:$PATH"

--- a/docker/transform/Dockerfile
+++ b/docker/transform/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 COPY ./pyproject.toml /code/pyproject.toml
+COPY ./uv.lock /code/uv.lock
 
 WORKDIR /code/src
 

--- a/docker/transform/Dockerfile
+++ b/docker/transform/Dockerfile
@@ -5,5 +5,5 @@ COPY ./pyproject.toml ./uv.lock /code/
 WORKDIR /code/src
 
 ENV UV_LINK_MODE=copy
-RUN uv sync --no-dev
+RUN uv sync --frozen --no-dev
 ENV PATH="/code/.venv/bin:$PATH"


### PR DESCRIPTION
- Copy src and config into the image for production (no bind mounts from local fs)
- Copy `uv.lock` on image build before dependency resolution to use locked versions