### PR TITLE
fix(gh ci cd): cache fastembed model 

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -36,6 +36,14 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
+            -   name: Cache FastEmbed models
+                uses: actions/cache@v4
+                with:
+                    path: ./cache/fastembed
+                    key: fastembed-${{ hashFiles('uv.lock') }}
+                    restore-keys: |
+                        fastembed-
+
             -   name: Docker Build
                 run: docker compose build
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -37,7 +37,7 @@ jobs:
             -   uses: actions/checkout@v6
 
             -   name: Cache FastEmbed models
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: ./cache/fastembed
                     key: fastembed-${{ hashFiles('uv.lock') }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
         volumes:
             - ./src:/code/src
             - ./config:/code/config
+            - ./cache/fastembed:/root/.cache/fastembed
         networks:
             - warehouse-backend
         depends_on:
@@ -95,6 +96,7 @@ services:
         volumes:
             - ./src:/code/src
             - ./config:/code/config
+            - ./cache/fastembed:/root/.cache/fastembed
         command: [ "fastapi", "run", "--host", "0.0.0.0", "transform.py", "--port", "80" ]
         networks:
             - warehouse-backend

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -57,6 +57,8 @@ EMBEDDING_MODEL = os.environ.get('EMBEDDING_MODEL')
 if not EMBEDDING_MODEL:
     raise ValueError('Missing EMBEDDING_MODEL environment variable')
 
+FASTEMBED_CACHE_DIR = os.environ.get('FASTEMBED_CACHE_DIR', '/root/.cache/fastembed')
+
 celery_app = Celery('tasks')
 
 
@@ -248,7 +250,7 @@ class TransformTask(Task):  # type: ignore
 
     def __init__(self) -> None:
         if EMBEDDING_MODEL:
-            self.embedding_transformer = TextEmbedding(model_name=EMBEDDING_MODEL)
+            self.embedding_transformer = TextEmbedding(model_name=EMBEDDING_MODEL, cache_dir=FASTEMBED_CACHE_DIR)
             logger.info(f'Setting up embedding transformer with model {EMBEDDING_MODEL}')
 
         opensearch_config = OpenSearchConfig()

--- a/tests/test_embedding_utils.py
+++ b/tests/test_embedding_utils.py
@@ -34,7 +34,7 @@ class TestEmbeddingsUtils(unittest.TestCase):
                 textToEmbed='a title',
                 event=HarvestEventQueue(
                     id='1',
-                    xml='<root></root',
+                    xml='<root></root>',
                     repository_id='1',
                     endpoint_id='2',
                     record_identifier='xyz',
@@ -53,7 +53,7 @@ class TestEmbeddingsUtils(unittest.TestCase):
                 textToEmbed='a title 1',
                 event=HarvestEventQueue(
                     id='2',
-                    xml='<root></root',
+                    xml='<root></root>',
                     repository_id='1',
                     endpoint_id='2',
                     record_identifier='xyz',
@@ -72,7 +72,7 @@ class TestEmbeddingsUtils(unittest.TestCase):
                 textToEmbed='a title 2',
                 event=HarvestEventQueue(
                     id='3',
-                    xml='<root></root',
+                    xml='<root></root>',
                     repository_id='1',
                     endpoint_id='2',
                     record_identifier='xyz',

--- a/tests/test_embedding_utils.py
+++ b/tests/test_embedding_utils.py
@@ -25,8 +25,7 @@ class TestEmbeddingsUtils(unittest.TestCase):
         self.assertTrue('Consumentenconjunctuuronderzoek' in res)
 
     def test_add_embeddings_to_source(self):
-        embedding_model = TextEmbedding()
-        embedding_model.embed = MagicMock(name='embed')  # mock embed method
+        embedding_model = MagicMock(spec=TextEmbedding)
         embedding_model.embed.return_value = [np.array([1, 2, 3]), np.array([4, 5, 6]), np.array([7, 8, 9])]
 
         data = [


### PR DESCRIPTION
This PR adds support for caching the fastembed model.

- set up a bind mount in `docker-compose.yml` to cache the fastembed model 
- cache the model in the GH workflow (so it does not get downloaded on each run over and over again making the e2e tests flaky)
- mock the `TextEmbedding` class completely in the unit tests (no model needed at all) 