### PR TITLE
feat: add eodc set to onedata

### DIFF
--- a/scripts/postgres_data/create_sql/datasetdb/seed.sql
+++ b/scripts/postgres_data/create_sql/datasetdb/seed.sql
@@ -184,7 +184,7 @@ SELECT
     'OAI-PMH',
     'Multidisciplinary',
     true,
-    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e", "a93d0c2877c38910bd10bc458e266debch24b6", "6606a96229a922e4c757c0c99e593318ch4848"]}',
+    '{"metadata_prefix": "oai_datacite", "set": ["2a3d4828965cf74d7fc00d19c15715e7ch3d8e", "a93d0c2877c38910bd10bc458e266debch24b6", "6606a96229a922e4c757c0c99e593318ch4848", "551edb7ebcc12cc859b157854b24f539ch0c34"]}',
     INTERVAL '1 week'
 FROM repositories r
 WHERE r.code = 'ONE'


### PR DESCRIPTION
Code Scope:
- [x] Add EODC set to Onedata sets

Postgres Scope:
- [x] Add this set to prod PostgreSQL
- [x] Add this set to dev PostgreSQL
- [x] Delete Onedata's harvest_run on both dev and prod instances - harvest the sets once again because VIP records have changed