### PR TITLE
Add ROOT_PATH environment variable for Docker reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         environment:
             - OPENSEARCH_URL=http://opensearch:9200
             # Mount prefix for the Cyfronet reverse proxy so Swagger UI fetches /api/search/openapi.json
-            - ROOT_PATH=/api/search
+            - UVICORN_ROOT_PATH=/api/search
         networks:
             - warehouse-backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,6 +235,8 @@ services:
         env_file: [ keys.env ]
         environment:
             - OPENSEARCH_URL=http://opensearch:9200
+            # Mount prefix for the Cyfronet reverse proxy so Swagger UI fetches /api/search/openapi.json
+            - ROOT_PATH=/api/search
         networks:
             - warehouse-backend
 


### PR DESCRIPTION
This pull request adds a new environment variable to the `search` service configuration in `docker-compose.yml`. The `ROOT_PATH` variable is set to `/api/search` to ensure the Swagger UI correctly fetches the OpenAPI specification when running behind the Cyfronet reverse proxy.