### PR TITLE
chore(cdcd): us uv --locked flag for CI CD

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,7 +15,7 @@ jobs:
             -   name: Install uv
                 uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
             -   name: Install the project
-                run: uv sync --frozen --all-extras --group dev # https://docs.astral.sh/uv/guides/integration/github/#syncing-and-running
+                run: uv sync --locked --all-extras --group dev # https://docs.astral.sh/uv/guides/integration/github/#syncing-and-running
             -   name: Test with pytest
                 run: uv run pytest tests
             -   name: Check root mypy
@@ -67,7 +67,7 @@ jobs:
                 uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
             -   name: Install the project
-                run: uv sync --frozen --all-extras --dev
+                run: uv sync --locked --all-extras --dev
 
             -   name: Test with pytest
                 run: uv run pytest -s e2e


### PR DESCRIPTION
Use `uv sync --locked` in CI CD pipelines to detect deviations of `uv.lock` from `pyproject.toml.`

> Assert that the uv.lock will remain unchanged [env: UV_LOCKED=]
> Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated, uv will exit with an error.

https://docs.astral.sh/uv/reference/cli/#uv-run--locked

Note that we still use --frozen in Docker to install the exact versions defined in `uv.lock`.