### PR TITLE
feat: handle dependent endpoints in the scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ docker compose run harvester https://lifesciences.datastations.nl/oai
 The scheduler automates the full ingestion workflow: harvesting → transformation → indexing.
 It is designed to be executed periodically via CRON.
 
+### Dependent endpoints
+
+Some repositories are configured as dependent endpoints in the `endpoints` table by setting
+`depends_on_endpoint_id`. A dependent endpoint uses identifiers collected from its master
+endpoint, so the scheduler always triggers independent endpoints first and moves dependent
+endpoints to the end of the same harvesting batch. This ensures HAL is harvested before
+Zenodo when both endpoints are due for harvesting.
+
+The rest of the scheduler pipeline is unchanged: every selected endpoint is still crawled
+sequentially, the scheduler waits until harvest runs are closed, and then closed runs are
+sent to transformation/indexing.
+
 ### Run scheduler
 
 ```sh
@@ -229,4 +241,3 @@ Set up pre-commit hooks to check your messages before commiting them to the repo
 - `uv run pre-commit install --hook-type commit-msg`
 
 See `.pre-commit-config.yaml` for further details.
-

--- a/scheduler/clients/transformer_client.py
+++ b/scheduler/clients/transformer_client.py
@@ -8,13 +8,34 @@ Responsibilities:
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any
 
 import requests
 
 from scheduler.config import WAREHOUSE_API_URL
 
 logger = logging.getLogger(__name__)
+
+
+def order_runs_by_dependency(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Return harvest runs in scheduler execution order.
+
+    Endpoints with no dependency are triggered first. Endpoints with a
+    non-null `depends_on_endpoint_id` are triggered after all independent
+    endpoints so their master endpoints, for example HAL before Zenodo, have
+    a chance to finish harvesting before the dependent crawler opens its run.
+
+    The function uses a stable partition instead of computing a full
+    dependency graph: the database prevents direct self-dependency, and the
+    current scheduler requirement is only to defer configured dependent
+    endpoints to the end of the same scheduler batch.
+    """
+
+    independent_runs = [run for run in runs if run.get('depends_on_endpoint_id') is None]
+    dependent_runs = [run for run in runs if run.get('depends_on_endpoint_id') is not None]
+
+    return independent_runs + dependent_runs
 
 
 def get_endpoints_to_harvest() -> list[str]:
@@ -24,6 +45,9 @@ def get_endpoints_to_harvest() -> list[str]:
     Queries the transformer API and filters results by the
     `should_be_harvested` flag returned per endpoint, which reflects
     whether the endpoint is active and its harvest_schedule has elapsed.
+    Before returning URLs, the scheduler orders the selected endpoints so
+    independent endpoints run first and endpoints with a non-null
+    `depends_on_endpoint_id` run at the end of the batch.
 
     Returns
     -------
@@ -50,7 +74,9 @@ def get_endpoints_to_harvest() -> list[str]:
     data = r.json()
     runs = data.get('harvest_runs') or []
 
-    urls = [run['harvest_url'] for run in runs if run.get('should_be_harvested') and run['harvest_url'] is not None]
+    runs_to_harvest = [run for run in runs if run.get('should_be_harvested') and run.get('harvest_url') is not None]
+    ordered_runs = order_runs_by_dependency(runs_to_harvest)
+    urls = [run['harvest_url'] for run in ordered_runs]
 
     logger.info('%s endpoints require harvesting', len(urls))
 
@@ -71,7 +97,7 @@ def are_all_runs_closed() -> bool:
 
     r.raise_for_status()
 
-    data: Dict[str, Any] = r.json()
+    data: dict[str, Any] = r.json()
     result = bool(data['all_closed'])
 
     logger.debug('all runs closed = %s', result)
@@ -103,7 +129,7 @@ def get_closed_run_ids(all_runs: bool = False) -> list[str]:
     )
 
     r.raise_for_status()
-    data: Dict[str, Any] = r.json()
+    data: dict[str, Any] = r.json()
     run_ids = [str(x) for x in data.get('harvest_run_ids', [])]
 
     logger.info('%s closed runs found', len(run_ids))

--- a/src/app/api_classes.py
+++ b/src/app/api_classes.py
@@ -61,6 +61,10 @@ class HarvestRun(BaseModel):
 
     status: Optional[str] = Field(default=None, description='Status of the harvest run: open|closed|failed')
     harvest_url: str
+    depends_on_endpoint_id: str | None = Field(
+        default=None,
+        description='ID of the master endpoint that must be harvested before this endpoint, if configured',
+    )
     from_date: Optional[datetime]
     until_date: Optional[datetime]
     started_at: Optional[datetime]

--- a/src/app/db_methods.py
+++ b/src/app/db_methods.py
@@ -105,6 +105,7 @@ def get_latest_harvest_run_in_db(
         query = f"""
         SELECT
             e.harvest_url,
+            e.depends_on_endpoint_id,
             e.is_active,
             e.harvest_schedule,
             hr.id,
@@ -145,6 +146,7 @@ def get_latest_harvest_run_in_db(
                 id=str(r['id']) if r['id'] else None,
                 status=r['status'],
                 harvest_url=r['harvest_url'],
+                depends_on_endpoint_id=str(r['depends_on_endpoint_id']) if r['depends_on_endpoint_id'] else None,
                 from_date=r['from_date'],
                 until_date=r['until_date'],
                 started_at=r['started_at'],

--- a/tests/scheduler/clients/test_transformer_client.py
+++ b/tests/scheduler/clients/test_transformer_client.py
@@ -1,0 +1,118 @@
+from scheduler.clients import transformer_client
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+        self.raise_for_status_called = False
+
+    def raise_for_status(self):
+        self.raise_for_status_called = True
+
+    def json(self):
+        return self.payload
+
+
+def test_get_endpoints_to_harvest_requests_active_scheduled_runs(monkeypatch):
+    response = FakeResponse({'harvest_runs': []})
+    calls = []
+
+    def fake_get(url, params, timeout):
+        calls.append({'url': url, 'params': params, 'timeout': timeout})
+        return response
+
+    monkeypatch.setattr(transformer_client, 'WAREHOUSE_API_URL', 'http://warehouse-api.test')
+    monkeypatch.setattr(transformer_client.requests, 'get', fake_get)
+
+    assert transformer_client.get_endpoints_to_harvest() == []
+    assert calls == [
+        {
+            'url': 'http://warehouse-api.test/harvest_run',
+            'params': {'only_active': True, 'respect_schedule': True},
+            'timeout': 30,
+        }
+    ]
+    assert response.raise_for_status_called is True
+
+
+def test_get_endpoints_to_harvest_filters_unscheduled_and_invalid_runs(monkeypatch):
+    response = FakeResponse(
+        {
+            'harvest_runs': [
+                {
+                    'harvest_url': 'https://hal.science/oai/oai.php',
+                    'should_be_harvested': True,
+                    'depends_on_endpoint_id': None,
+                },
+                {
+                    'harvest_url': 'https://dabar.srce.hr/oai',
+                    'should_be_harvested': False,
+                    'depends_on_endpoint_id': None,
+                },
+                {
+                    'harvest_url': None,
+                    'should_be_harvested': True,
+                    'depends_on_endpoint_id': None,
+                },
+            ]
+        }
+    )
+
+    monkeypatch.setattr(transformer_client.requests, 'get', lambda *args, **kwargs: response)
+
+    assert transformer_client.get_endpoints_to_harvest() == [
+        'https://hal.science/oai/oai.php',
+    ]
+
+
+def test_get_endpoints_to_harvest_defers_dependent_runs_to_end(monkeypatch):
+    response = FakeResponse(
+        {
+            'harvest_runs': [
+                {
+                    'harvest_url': 'https://zenodo.org/oai2d',
+                    'should_be_harvested': True,
+                    'depends_on_endpoint_id': 'hal-endpoint-id',
+                },
+                {
+                    'harvest_url': 'https://hal.science/oai/oai.php',
+                    'should_be_harvested': True,
+                    'depends_on_endpoint_id': None,
+                },
+                {
+                    'harvest_url': 'https://dependent.example.test/oai',
+                    'should_be_harvested': True,
+                    'depends_on_endpoint_id': 'other-master-id',
+                },
+            ]
+        }
+    )
+
+    monkeypatch.setattr(transformer_client.requests, 'get', lambda *args, **kwargs: response)
+
+    assert transformer_client.get_endpoints_to_harvest() == [
+        'https://hal.science/oai/oai.php',
+        'https://zenodo.org/oai2d',
+        'https://dependent.example.test/oai',
+    ]
+
+
+def test_order_runs_by_dependency_preserves_transformer_order_inside_each_group():
+    first_dependent = {'harvest_url': 'dependent-a', 'depends_on_endpoint_id': 'master-a'}
+    first_independent = {'harvest_url': 'independent-a', 'depends_on_endpoint_id': None}
+    second_dependent = {'harvest_url': 'dependent-b', 'depends_on_endpoint_id': 'master-b'}
+    second_independent = {'harvest_url': 'independent-b'}
+
+    assert transformer_client.order_runs_by_dependency(
+        [
+            first_dependent,
+            first_independent,
+            second_dependent,
+            second_independent,
+        ]
+    ) == [
+        first_independent,
+        second_independent,
+        first_dependent,
+        second_dependent,
+    ]


### PR DESCRIPTION
## Scope

This PR updates the scheduler to respect endpoint dependencies introduced by the dependent endpoint schema changes.

Endpoints with `depends_on_endpoint_id IS NULL` are triggered first. Endpoints with `depends_on_endpoint_id IS NOT NULL`, currently Zenodo depending on HAL, are moved to the end of the same scheduler harvesting batch.

## Changes

- Expose `depends_on_endpoint_id` in the `/harvest_run` response so the scheduler can see dependency configuration.
- Add scheduler-side ordering that stable-partitions harvest runs:
  - independent endpoints first
  - dependent endpoints last
- Preserve the rest of the pipeline unchanged:
  - crawler execution remains sequential
  - scheduler still waits for harvest runs to close
  - closed runs are still sent to transformation/indexing
- Document the dependent endpoint behavior in the README.
- Add tests for dependent endpoint ordering and stable ordering within each group.

## Notes

This does not implement full dependency graph sorting or cycle detection. It follows the current operational requirement: defer configured dependent endpoints to the end of the scheduler batch so HAL is harvested before Zenodo when both are due.

# Run Scheduler

`docker compose --profile manual run -d scheduler`